### PR TITLE
New installation check improvement

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -z "$(ls -A /var/lib/mysql)" -a "${1%_safe}" = 'mysqld' ]; then
+if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
 		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -z "$(ls -A /var/lib/mysql)" -a "${1%_safe}" = 'mysqld' ]; then
+if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
 		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -z "$(ls -A /var/lib/mysql)" -a "${1%_safe}" = 'mysqld' ]; then
+if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
 		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'


### PR DESCRIPTION
Checks if the database "mysql" has been installed (i.e. the directory
"mysql" exists in the mysql data directory) instead of checking if
the directory is empty.

For example, the directory may not be empty if a dedicated filesystem
is used for the mysql data and thus a "lost+found" is present in the
directory:

```
dd if=/dev/zero of=/tmp/mysql-data.img bs=1024 count=1048576
mkfs.ext4 /tmp/mysql-data.img
mount /tmp/mysql-data.img /mnt
docker run -v /mnt:/var/lib/mysql -t mysql
```
