### PR TITLE
Feature: adding hook to execute additional scripts on startup

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -39,6 +39,8 @@ ENV PATH $PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts
 WORKDIR /usr/local/mysql
 VOLUME /var/lib/mysql
 
+RUN mkdir -p /docker-entrypoint-initdb.d
+
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -33,6 +33,13 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 		fi
 	fi
 	
+	INIT_DIR='/docker-entrypoint-initdb.d'
+        for f in $INIT_DIR/*.sql
+        do 
+                echo "Appending sql script: $f"
+                cat $f >> "$TEMP_FILE"
+        done
+	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
 	
 	set -- "$@" --init-file="$TEMP_FILE"

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -36,8 +36,10 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	INIT_DIR='/docker-entrypoint-initdb.d'
         for f in $INIT_DIR/*.sql
         do 
+            if [ -f $f ]; then
                 echo "Appending sql script: $f"
                 cat $f >> "$TEMP_FILE"
+            fi
         done
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -39,6 +39,8 @@ ENV PATH $PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts
 WORKDIR /usr/local/mysql
 VOLUME /var/lib/mysql
 
+RUN mkdir -p /docker-entrypoint-initdb.d
+
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -33,6 +33,13 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 		fi
 	fi
 	
+	INIT_DIR='/docker-entrypoint-initdb.d'
+        for f in $INIT_DIR/*.sql
+        do 
+                echo "Appending sql script: $f"
+                cat $f >> "$TEMP_FILE"
+        done
+	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
 	
 	set -- "$@" --init-file="$TEMP_FILE"

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -36,8 +36,10 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	INIT_DIR='/docker-entrypoint-initdb.d'
         for f in $INIT_DIR/*.sql
         do 
+            if [ -f $f ]; then
                 echo "Appending sql script: $f"
                 cat $f >> "$TEMP_FILE"
+            fi
         done
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -39,6 +39,8 @@ ENV PATH $PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts
 WORKDIR /usr/local/mysql
 VOLUME /var/lib/mysql
 
+RUN mkdir -p /docker-entrypoint-initdb.d
+
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -33,6 +33,13 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 		fi
 	fi
 	
+	INIT_DIR='/docker-entrypoint-initdb.d'
+        for f in $INIT_DIR/*.sql
+        do 
+                echo "Appending sql script: $f"
+                cat $f >> "$TEMP_FILE"
+        done
+	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
 	
 	set -- "$@" --init-file="$TEMP_FILE"

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -36,8 +36,10 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	INIT_DIR='/docker-entrypoint-initdb.d'
         for f in $INIT_DIR/*.sql
         do 
+            if [ -f $f ]; then
                 echo "Appending sql script: $f"
                 cat $f >> "$TEMP_FILE"
+            fi
         done
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"


### PR DESCRIPTION
This will close both #18 and #24.

The scripts are located in the /docker-entrypoint-initdb.d directory.

Paired on this with @benkiefer