### PR TITLE
improve the start speed of the container 

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -37,9 +37,14 @@ RUN apt-get update && apt-get install -y curl --no-install-recommends && rm -rf 
 ENV PATH $PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts
 
 WORKDIR /usr/local/mysql
+RUN mysql_install_db --user=mysql --datadir=/var/lib/mysql
+
+RUN chown -R mysql:mysql /var/lib/mysql
+
 VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -1,42 +1,37 @@
 #!/bin/bash
 set -e
 
-if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
-	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
-		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
-		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
-		exit 1
-	fi
-	
-	mysql_install_db --user=mysql --datadir=/var/lib/mysql
-	
-	# These statements _must_ be on individual lines, and _must_ end with
-	# semicolons (no line breaks or comments are permitted).
-	# TODO proper SQL escaping on ALL the things D:
-	TEMP_FILE='/tmp/mysql-first-time.sql'
-	cat > "$TEMP_FILE" <<-EOSQL
-		DELETE FROM mysql.user ;
-		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-		DROP DATABASE IF EXISTS test ;
-	EOSQL
-	
-	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE ;" >> "$TEMP_FILE"
-	fi
-	
-	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-		echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$TEMP_FILE"
-		
-		if [ "$MYSQL_DATABASE" ]; then
-			echo "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%' ;" >> "$TEMP_FILE"
-		fi
-	fi
-	
-	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
-	
-	set -- "$@" --init-file="$TEMP_FILE"
+if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
+	echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
+	echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
+	exit 1
 fi
+
+# semicolons (no line breaks or comments are permitted).
+# TODO proper SQL escaping on ALL the things D:
+TEMP_FILE='/tmp/mysql-first-time.sql'
+cat > "$TEMP_FILE" <<-EOSQL
+	DELETE FROM mysql.user ;
+	CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+	GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+	DROP DATABASE IF EXISTS test ;
+EOSQL
+
+if [ "$MYSQL_DATABASE" ]; then
+	echo "CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE ;" >> "$TEMP_FILE"
+fi
+
+if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+	echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$TEMP_FILE"
+		
+	if [ "$MYSQL_DATABASE" ]; then
+		echo "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%' ;" >> "$TEMP_FILE"
+	fi
+fi
+	
+echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
+	
+set -- "$@" --init-file="$TEMP_FILE"
 
 chown -R mysql:mysql /var/lib/mysql
 exec "$@"


### PR DESCRIPTION
We were noticing a significant decrease in container start time compared to when we were using the postgres container (20 seconds w/mysql vs 2 seconds) and started to do some debugging to figure out where the pain was. It turns out it came mostly from 'mysql_install_db' step in the entrypoint. Since this container is opinionated about always using the mysql user anyway, it seemed to make sense to move this to the initial build of the container, rather than as part of the run.

The container now starts up in 2-3 seconds. 

I'd like to know what you think of this, and if there were any reasons that the mysql_install_db step was part of the entrypoint vs part of the container build.

I only applied this change to 5.7 because I wanted to talk about it before going down the route of making this change to all three versions.

Thanks for the feedback.
