### PR TITLE
Add support for configurable mysqld flags

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -43,4 +43,4 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306
-CMD ["mysqld", "--datadir=/var/lib/mysql", "--user=mysql"]
+CMD ["mysqld"]

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -34,9 +34,19 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	fi
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
-	
-	set -- "$@" --init-file="$TEMP_FILE"
+	chown -R mysql:mysql /var/lib/mysql
 fi
 
-chown -R mysql:mysql /var/lib/mysql
+if [[ "$@" = 'mysqld' ]]; then
+	set -- "$@" --datadir=/var/lib/mysql --user=mysql
+
+	if [ -n "$TEMP_FILE" ]; then
+		set -- "$@" --init-file="$TEMP_FILE"
+	fi
+
+	if [ -n "$MYSQLD_FLAGS" ]; then
+		set -- "$@" "$MYSQLD_FLAGS"
+	fi
+fi
+
 exec "$@"

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -43,4 +43,4 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306
-CMD ["mysqld", "--datadir=/var/lib/mysql", "--user=mysql"]
+CMD ["mysqld"]

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -34,9 +34,19 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	fi
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
-	
-	set -- "$@" --init-file="$TEMP_FILE"
+	chown -R mysql:mysql /var/lib/mysql
 fi
 
-chown -R mysql:mysql /var/lib/mysql
+if [[ "$@" = 'mysqld' ]]; then
+	set -- "$@" --datadir=/var/lib/mysql --user=mysql
+
+	if [ -n "$TEMP_FILE" ]; then
+		set -- "$@" --init-file="$TEMP_FILE"
+	fi
+
+	if [ -n "$MYSQLD_FLAGS" ]; then
+		set -- "$@" "$MYSQLD_FLAGS"
+	fi
+fi
+
 exec "$@"

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -43,4 +43,4 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306
-CMD ["mysqld", "--datadir=/var/lib/mysql", "--user=mysql"]
+CMD ["mysqld"]

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -34,9 +34,19 @@ if [ ! -d '/var/lib/mysql/mysql' -a "${1%_safe}" = 'mysqld' ]; then
 	fi
 	
 	echo 'FLUSH PRIVILEGES ;' >> "$TEMP_FILE"
-	
-	set -- "$@" --init-file="$TEMP_FILE"
+	chown -R mysql:mysql /var/lib/mysql
 fi
 
-chown -R mysql:mysql /var/lib/mysql
+if [[ "$@" = 'mysqld' ]]; then
+	set -- "$@" --datadir=/var/lib/mysql --user=mysql
+
+	if [ -n "$TEMP_FILE" ]; then
+		set -- "$@" --init-file="$TEMP_FILE"
+	fi
+
+	if [ -n "$MYSQLD_FLAGS" ]; then
+		set -- "$@" "$MYSQLD_FLAGS"
+	fi
+fi
+
 exec "$@"


### PR DESCRIPTION
Example use case:

<code>
docker run -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=secret -e MYSQLD_FLAGS="--innodb_autoinc_lock_mode=0" -d mysql</code>
