### PR TITLE
Update entrypoints to read DATADIR from the MySQL configuration directly instead of assuming /var/lib/docker

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -1,52 +1,55 @@
 #!/bin/bash
 set -e
 
-# TODO read this from the MySQL config?
-DATADIR='/var/lib/mysql'
-
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
-if [ ! -d "$DATADIR/mysql" -a "${1%_safe}" = 'mysqld' ]; then
-	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
-		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
-		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
-		exit 1
-	fi
+if [ "$1" = 'mysqld' ]; then
+	# read DATADIR from the MySQL config
+	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	
-	echo 'Running mysql_install_db ...'
-	mysql_install_db --basedir=/usr/local/mysql
-	echo 'Finished mysql_install_db'
-	
-	# These statements _must_ be on individual lines, and _must_ end with
-	# semicolons (no line breaks or comments are permitted).
-	# TODO proper SQL escaping on ALL the things D:
-	
-	tempSqlFile='/tmp/mysql-first-time.sql'
-	cat > "$tempSqlFile" <<-EOSQL
-		DELETE FROM mysql.user ;
-		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-		DROP DATABASE IF EXISTS test ;
-	EOSQL
-	
-	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
-	fi
-	
-	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-		echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+	if [ ! -d "$DATADIR/mysql" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
+			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
+			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
+			exit 1
+		fi
+		
+		echo 'Running mysql_install_db ...'
+		mysql_install_db --datadir="$DATADIR" --basedir=/usr/local/mysql
+		echo 'Finished mysql_install_db'
+		
+		# These statements _must_ be on individual lines, and _must_ end with
+		# semicolons (no line breaks or comments are permitted).
+		# TODO proper SQL escaping on ALL the things D:
+		
+		tempSqlFile='/tmp/mysql-first-time.sql'
+		cat > "$tempSqlFile" <<-EOSQL
+			DELETE FROM mysql.user ;
+			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			DROP DATABASE IF EXISTS test ;
+		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
 		fi
+		
+		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			
+			if [ "$MYSQL_DATABASE" ]; then
+				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			fi
+		fi
+		
+		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
+		
+		set -- "$@" --init-file="$tempSqlFile"
 	fi
 	
-	echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-	
-	set -- "$@" --init-file="$tempSqlFile"
+	chown -R mysql:mysql "$DATADIR"
 fi
 
-chown -R mysql:mysql "$DATADIR"
 exec "$@"

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -1,52 +1,55 @@
 #!/bin/bash
 set -e
 
-# TODO read this from the MySQL config?
-DATADIR='/var/lib/mysql'
-
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
-if [ ! -d "$DATADIR/mysql" -a "${1%_safe}" = 'mysqld' ]; then
-	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
-		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
-		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
-		exit 1
-	fi
+if [ "$1" = 'mysqld' ]; then
+	# read DATADIR from the MySQL config
+	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	
-	echo 'Running mysql_install_db ...'
-	mysql_install_db
-	echo 'Finished mysql_install_db'
-	
-	# These statements _must_ be on individual lines, and _must_ end with
-	# semicolons (no line breaks or comments are permitted).
-	# TODO proper SQL escaping on ALL the things D:
-	
-	tempSqlFile='/tmp/mysql-first-time.sql'
-	cat > "$tempSqlFile" <<-EOSQL
-		DELETE FROM mysql.user ;
-		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-		DROP DATABASE IF EXISTS test ;
-	EOSQL
-	
-	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
-	fi
-	
-	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-		echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+	if [ ! -d "$DATADIR/mysql" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
+			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
+			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
+			exit 1
+		fi
+		
+		echo 'Running mysql_install_db ...'
+		mysql_install_db --datadir="$DATADIR"
+		echo 'Finished mysql_install_db'
+		
+		# These statements _must_ be on individual lines, and _must_ end with
+		# semicolons (no line breaks or comments are permitted).
+		# TODO proper SQL escaping on ALL the things D:
+		
+		tempSqlFile='/tmp/mysql-first-time.sql'
+		cat > "$tempSqlFile" <<-EOSQL
+			DELETE FROM mysql.user ;
+			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			DROP DATABASE IF EXISTS test ;
+		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
 		fi
+		
+		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			
+			if [ "$MYSQL_DATABASE" ]; then
+				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			fi
+		fi
+		
+		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
+		
+		set -- "$@" --init-file="$tempSqlFile"
 	fi
 	
-	echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-	
-	set -- "$@" --init-file="$tempSqlFile"
+	chown -R mysql:mysql "$DATADIR"
 fi
 
-chown -R mysql:mysql "$DATADIR"
 exec "$@"

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -1,52 +1,55 @@
 #!/bin/bash
 set -e
 
-# TODO read this from the MySQL config?
-DATADIR='/var/lib/mysql'
-
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
-if [ ! -d "$DATADIR/mysql" -a "${1%_safe}" = 'mysqld' ]; then
-	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
-		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
-		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
-		exit 1
-	fi
+if [ "$1" = 'mysqld' ]; then
+	# read DATADIR from the MySQL config
+	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	
-	echo 'Running mysql_install_db ...'
-	mysql_install_db --datadir="$DATADIR" --mysqld-file="$(which mysqld)"
-	echo 'Finished mysql_install_db'
-	
-	# These statements _must_ be on individual lines, and _must_ end with
-	# semicolons (no line breaks or comments are permitted).
-	# TODO proper SQL escaping on ALL the things D:
-	
-	tempSqlFile='/tmp/mysql-first-time.sql'
-	cat > "$tempSqlFile" <<-EOSQL
-		DELETE FROM mysql.user ;
-		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-		DROP DATABASE IF EXISTS test ;
-	EOSQL
-	
-	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
-	fi
-	
-	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-		echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+	if [ ! -d "$DATADIR/mysql" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
+			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
+			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
+			exit 1
+		fi
+		
+		echo 'Running mysql_install_db ...'
+		mysql_install_db --datadir="$DATADIR" --mysqld-file="$(which "$1")"
+		echo 'Finished mysql_install_db'
+		
+		# These statements _must_ be on individual lines, and _must_ end with
+		# semicolons (no line breaks or comments are permitted).
+		# TODO proper SQL escaping on ALL the things D:
+		
+		tempSqlFile='/tmp/mysql-first-time.sql'
+		cat > "$tempSqlFile" <<-EOSQL
+			DELETE FROM mysql.user ;
+			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			DROP DATABASE IF EXISTS test ;
+		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
 		fi
+		
+		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			
+			if [ "$MYSQL_DATABASE" ]; then
+				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+			fi
+		fi
+		
+		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
+		
+		set -- "$@" --init-file="$tempSqlFile"
 	fi
 	
-	echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-	
-	set -- "$@" --init-file="$tempSqlFile"
+	chown -R mysql:mysql "$DATADIR"
 fi
 
-chown -R mysql:mysql "$DATADIR"
 exec "$@"


### PR DESCRIPTION
Don't be afraid -- most of the diff is reindentation!

This will actually let `datadir` be defined anywhere in the config (even in `conf.d` files and the command line via `docker run <image> mysqld --datadir=/somewhere/else`, which is how I was primarily testing the change) because we're letting MySQL itself tell us what the value should be.

Fixes #40
Closes #42