### PR TITLE
Fix issue in Entrypoint

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'mysqld' ]; then
 	# read DATADIR from the MySQL config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "$DATADIR" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'


### PR DESCRIPTION
- The datadir is retrieve from the config, we don't need to add /mysql to the result
- This induces a myslq_install_db at each docker run which is not the intended behavior