### PR TITLE
Prevent root password from being accessible by normal users on first run

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 set -e
 
+get_option () {
+    local section=$1
+    local option=$2
+    local default=$3
+    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+    [ -z $ret ] && ret=$default
+    echo $ret
+}
+
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
 if [ "$1" = 'mysqld' ]; then
-	# read DATADIR from the MySQL config
-	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+	# Get config
+        DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 	
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
@@ -16,16 +27,27 @@ if [ "$1" = 'mysqld' ]; then
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
-		
-		echo 'Running mysql_install_db ...'
-		mysql_install_db --datadir="$DATADIR" --basedir=/usr/local/mysql
+		mkdir -p $DATADIR
+		echo 'Running mysql_install_db'
+		mysql_install_db --user=mysql --datadir=$DATADIR --rpm
 		echo 'Finished mysql_install_db'
-		
+
+		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] && break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL init process failed.'
+                    exit 1
+                fi
+                
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
 		
-		tempSqlFile='/tmp/mysql-first-time.sql'
+		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
 			--  or products like mysql-fabric won't work
@@ -38,23 +60,35 @@ if [ "$1" = 'mysqld' ]; then
 		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
 		
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
 			
 			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
 		
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 		
-		set -- "$@" --init-file="$tempSqlFile"
+		chown -R mysql:mysql "$DATADIR"
+		mysql -uroot < $tempSqlFile
+
+		rm -f $tempSqlFile
+		kill $(cat $PIDFILE)
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] || break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL hangs during init process.'
+                    exit 1
+                fi
+		echo 'MySQL init process done. Ready for start up.'
 	fi
-	
-	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -90,6 +90,8 @@ if [ "$1" = 'mysqld' ]; then
                 fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
+
+	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -28,16 +28,16 @@ if [ "$1" = 'mysqld' ]; then
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
-		mkdir -p $DATADIR
+		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 
 		echo 'Running mysql_install_db'
-		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --basedir=/usr/local/mysql
+		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --basedir=/usr/local/mysql
 		echo 'Finished mysql_install_db'
 
-		mysqld --user=mysql --datadir=$DATADIR --skip-networking --basedir=/usr/local/mysql &
+		mysqld --user=mysql --datadir="$DATADIR" --skip-networking --basedir=/usr/local/mysql &
 		for i in $(seq 30 -1 0); do
-			[ -S $SOCKET ] && break
+			[ -S "$SOCKET" ] && break
 			echo 'MySQL init process in progress...'
 			sleep 1
 		done
@@ -76,9 +76,9 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < $tempSqlFile
+		mysql -uroot < "$tempSqlFile"
 
-		rm -f $tempSqlFile
+		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
 			[ -S $SOCKET ] || break

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -2,12 +2,12 @@
 set -e
 
 get_option () {
-    local section=$1
-    local option=$2
-    local default=$3
-    ret=$(/usr/local/mysql/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
-    [ -z $ret ] && ret=$default
-    echo $ret
+	local section=$1
+	local option=$2
+	local default=$3
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	[ -z $ret ] && ret=$default
+	echo $ret
 }
 
 # if command starts with an option, prepend mysqld
@@ -17,11 +17,11 @@ fi
 
 if [ "$1" = 'mysqld' ]; then
 	# Get config
-        DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-        SOCKET=$(get_option  mysqld socket "/tmp/mysql.sock")
-        HOSTNAME=$(hostname)
-        PIDFILE=$(get_option mysqld pid-file "$DATADIR/$HOSTNAME.pid")
-	
+	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+	SOCKET=$(get_option  mysqld socket "/tmp/mysql.sock")
+	HOSTNAME=$(hostname)
+	PIDFILE=$(get_option mysqld pid-file "$DATADIR/$HOSTNAME.pid")
+
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
@@ -29,25 +29,27 @@ if [ "$1" = 'mysqld' ]; then
 			exit 1
 		fi
 		mkdir -p $DATADIR
+		chown -R mysql:mysql "$DATADIR"
+
 		echo 'Running mysql_install_db'
 		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --basedir=/usr/local/mysql
 		echo 'Finished mysql_install_db'
 
 		mysqld --user=mysql --datadir=$DATADIR --skip-networking --basedir=/usr/local/mysql &
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] && break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] && break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL init process failed.'
-                    exit 1
-                fi
-                
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
-		
+
 		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
@@ -59,35 +61,34 @@ if [ "$1" = 'mysqld' ]; then
 			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 			DROP DATABASE IF EXISTS test ;
 		EOSQL
-		
+
 		if [ "$MYSQL_DATABASE" ]; then
 			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
-		
+
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
-			
+
 			if [ "$MYSQL_DATABASE" ]; then
 				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
-		
+
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-		
-		chown -R mysql:mysql "$DATADIR"
+
 		mysql -uroot < $tempSqlFile
 
 		rm -f $tempSqlFile
 		kill $(cat $PIDFILE)
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] || break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] || break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL hangs during init process.'
-                    exit 1
-                fi
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL hangs during init process.'
+			exit 1
+		fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
 

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -5,7 +5,7 @@ get_option () {
     local section=$1
     local option=$2
     local default=$3
-    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+    ret=$(/usr/local/mysql/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
     [ -z $ret ] && ret=$default
     echo $ret
 }
@@ -18,8 +18,9 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# Get config
         DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
-        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+        SOCKET=$(get_option  mysqld socket "/tmp/mysql.sock")
+        HOSTNAME=$(hostname)
+        PIDFILE=$(get_option mysqld pid-file "$DATADIR/$HOSTNAME.pid")
 	
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
@@ -29,10 +30,10 @@ if [ "$1" = 'mysqld' ]; then
 		fi
 		mkdir -p $DATADIR
 		echo 'Running mysql_install_db'
-		mysql_install_db --user=mysql --datadir=$DATADIR --rpm
+		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --basedir=/usr/local/mysql
 		echo 'Finished mysql_install_db'
 
-		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+		mysqld --user=mysql --datadir=$DATADIR --skip-networking --basedir=/usr/local/mysql &
                 for i in $(seq 30 -1 0); do
 		    [ -S $SOCKET ] && break
 		    echo 'MySQL init process in progress...'

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -27,6 +27,7 @@ if [ "$1" = 'mysqld' ]; then
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
+
 		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 
@@ -62,7 +63,7 @@ if [ "$1" = 'mysqld' ]; then
 		EOSQL
 
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
@@ -80,7 +81,7 @@ if [ "$1" = 'mysqld' ]; then
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
-			[ -S $SOCKET ] || break
+			[ -f "$PIDFILE" ] || break
 			echo 'MySQL init process in progress...'
 			sleep 1
 		done

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -2,12 +2,12 @@
 set -e
 
 get_option () {
-    local section=$1
-    local option=$2
-    local default=$3
-    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
-    [ -z $ret ] && ret=$default
-    echo $ret
+	local section=$1
+	local option=$2
+	local default=$3
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	[ -z $ret ] && ret=$default
+	echo $ret
 }
 
 # if command starts with an option, prepend mysqld
@@ -18,8 +18,8 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
-        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+	SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+	PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
@@ -28,25 +28,27 @@ if [ "$1" = 'mysqld' ]; then
 			exit 1
 		fi
 		mkdir -p $DATADIR
+		chown -R mysql:mysql "$DATADIR"
+
 		echo 'Running mysql_install_db'
 		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --keep-my-cnf
 		echo 'Finished mysql_install_db'
 
 		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] && break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] && break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL init process failed.'
-                    exit 1
-                fi
-                
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
-		
+
 		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
@@ -58,35 +60,34 @@ if [ "$1" = 'mysqld' ]; then
 			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 			DROP DATABASE IF EXISTS test ;
 		EOSQL
-		
+
 		if [ "$MYSQL_DATABASE" ]; then
 			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
-		
+
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
-			
+
 			if [ "$MYSQL_DATABASE" ]; then
 				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
-		
+
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-		
-		chown -R mysql:mysql "$DATADIR"
+
 		mysql -uroot < $tempSqlFile
 
 		rm -f $tempSqlFile
 		kill $(cat $PIDFILE)
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] || break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] || break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL hangs during init process.'
-                    exit 1
-                fi
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL hangs during init process.'
+			exit 1
+		fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -1,31 +1,53 @@
 #!/bin/bash
 set -e
 
+get_option () {
+    local section=$1
+    local option=$2
+    local default=$3
+    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+    [ -z $ret ] && ret=$default
+    echo $ret
+}
+
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
 if [ "$1" = 'mysqld' ]; then
-	# read DATADIR from the MySQL config
+	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	
+        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
-		
-		echo 'Running mysql_install_db ...'
-		mysql_install_db --datadir="$DATADIR"
+		mkdir -p $DATADIR
+		echo 'Running mysql_install_db'
+		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --keep-my-cnf
 		echo 'Finished mysql_install_db'
-		
+
+		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] && break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL init process failed.'
+                    exit 1
+                fi
+                
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
 		
-		tempSqlFile='/tmp/mysql-first-time.sql'
+		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
 			--  or products like mysql-fabric won't work
@@ -38,23 +60,35 @@ if [ "$1" = 'mysqld' ]; then
 		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
 		
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
 			
 			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
 		
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 		
-		set -- "$@" --init-file="$tempSqlFile"
+		chown -R mysql:mysql "$DATADIR"
+		mysql -uroot < $tempSqlFile
+
+		rm -f $tempSqlFile
+		kill $(cat $PIDFILE)
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] || break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL hangs during init process.'
+                    exit 1
+                fi
+		echo 'MySQL init process done. Ready for start up.'
 	fi
-	
-	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -89,6 +89,8 @@ if [ "$1" = 'mysqld' ]; then
                 fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
+
+	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -18,7 +18,7 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+	SOCKET=$(get_option  mysqld socket "$DATADIR/mysql.sock")
 	PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 
 	if [ ! -d "$DATADIR/mysql" ]; then
@@ -27,16 +27,16 @@ if [ "$1" = 'mysqld' ]; then
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
-		mkdir -p $DATADIR
+		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 
 		echo 'Running mysql_install_db'
-		mysql_install_db --user=mysql --datadir=$DATADIR --rpm --keep-my-cnf
+		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --keep-my-cnf
 		echo 'Finished mysql_install_db'
 
-		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+		mysqld --user=mysql --datadir="$DATADIR" --skip-networking &
 		for i in $(seq 30 -1 0); do
-			[ -S $SOCKET ] && break
+			[ -S "$SOCKET" ] && break
 			echo 'MySQL init process in progress...'
 			sleep 1
 		done
@@ -75,9 +75,9 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < $tempSqlFile
+		mysql -uroot < "$tempSqlFile"
 
-		rm -f $tempSqlFile
+		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
 			[ -S $SOCKET ] || break

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -30,6 +30,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
+
 		echo 'Initializing database'
 		mysqld --initialize-insecure=on --datadir="$DATADIR"
 		echo 'Database initialized'
@@ -66,7 +67,7 @@ if [ "$1" = 'mysqld' ]; then
 		EOSQL
 
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
@@ -83,7 +84,7 @@ if [ "$1" = 'mysqld' ]; then
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
-			[ -S $SOCKET ] || break
+			[ -f "$PIDFILE" ] || break
 			echo 'MySQL init process in progress...'
 			sleep 1
 		done

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -18,7 +18,7 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+	SOCKET=$(get_option  mysqld socket "$DATADIR/mysql.sock")
 	PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 
 	if [ ! -d "$DATADIR/mysql" ]; then
@@ -28,13 +28,13 @@ if [ "$1" = 'mysqld' ]; then
 			exit 1
 		fi
 
-		mkdir -p $DATADIR
+		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 		echo 'Initializing database'
 		mysqld --initialize-insecure=on --datadir="$DATADIR"
 		echo 'Database initialized'
 
-		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+		mysqld --user=mysql --datadir="$DATADIR" --skip-networking &
 		for i in $(seq 30 -1 0); do
 			[ -S $SOCKET ] && break
 			echo 'MySQL init process in progress...'
@@ -79,8 +79,8 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < $tempSqlFile
-		rm -f $tempSqlFile
+		mysql -uroot < "$tempSqlFile"
+		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
 			[ -S $SOCKET ] || break

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -93,6 +93,8 @@ if [ "$1" = 'mysqld' ]; then
                 fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
+
+	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -2,12 +2,12 @@
 set -e
 
 get_option () {
-    local section=$1
-    local option=$2
-    local default=$3
-    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
-    [ -z $ret ] && ret=$default
-    echo $ret
+	local section=$1
+	local option=$2
+	local default=$3
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	[ -z $ret ] && ret=$default
+	echo $ret
 }
 
 # if command starts with an option, prepend mysqld
@@ -18,8 +18,8 @@ fi
 if [ "$1" = 'mysqld' ]; then
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
-        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+	SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+	PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
@@ -29,21 +29,22 @@ if [ "$1" = 'mysqld' ]; then
 		fi
 
 		mkdir -p $DATADIR
+		chown -R mysql:mysql "$DATADIR"
 		echo 'Initializing database'
 		mysqld --initialize-insecure=on --datadir="$DATADIR"
 		echo 'Database initialized'
 
 		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] && break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] && break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL init process failed.'
-                    exit 1
-                fi
-                
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
 		# Workaround for bug in 5.7 that doesn't clean up after itself correctly 
 		rm -f $DATADIR/ib_logfile0
 		rm -f $DATADIR/ib_logfile1
@@ -51,7 +52,7 @@ if [ "$1" = 'mysqld' ]; then
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
-		
+
 		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
@@ -63,34 +64,33 @@ if [ "$1" = 'mysqld' ]; then
 			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 			DROP DATABASE IF EXISTS test ;
 		EOSQL
-		
+
 		if [ "$MYSQL_DATABASE" ]; then
 			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
-		
+
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
-			
+
 			if [ "$MYSQL_DATABASE" ]; then
 				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
-		
+
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
-		
-		chown -R mysql:mysql "$DATADIR"
+
 		mysql -uroot < $tempSqlFile
 		rm -f $tempSqlFile
 		kill $(cat $PIDFILE)
-                for i in $(seq 30 -1 0); do
-		    [ -S $SOCKET ] || break
-		    echo 'MySQL init process in progress...'
-		    sleep 1
+		for i in $(seq 30 -1 0); do
+			[ -S $SOCKET ] || break
+			echo 'MySQL init process in progress...'
+			sleep 1
 		done
-                if [ $i = 0 ]; then
-                    echo >&2 'MySQL hangs during init process.'
-                    exit 1
-                fi
+		if [ $i = 0 ]; then
+			echo >&2 'MySQL hangs during init process.'
+			exit 1
+		fi
 		echo 'MySQL init process done. Ready for start up.'
 	fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -1,31 +1,54 @@
 #!/bin/bash
 set -e
 
+get_option () {
+    local section=$1
+    local option=$2
+    local default=$3
+    ret=$(/usr/bin/my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+    [ -z $ret ] && ret=$default
+    echo $ret
+}
+
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
 	set -- mysqld "$@"
 fi
 
 if [ "$1" = 'mysqld' ]; then
-	# read DATADIR from the MySQL config
+	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
-	
+        SOCKET=$(get_option  mysqld socket "$datadir/mysql.sock")
+        PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
 			echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
 			exit 1
 		fi
-		
+
+		mkdir -p $DATADIR
 		echo 'Initializing database'
 		mysqld --initialize-insecure=on --datadir="$DATADIR"
 		echo 'Database initialized'
-		
+
+		mysqld --user=mysql --datadir=$DATADIR --skip-networking &
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] && break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL init process failed.'
+                    exit 1
+                fi
+                
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
 		
-		tempSqlFile='/tmp/mysql-first-time.sql'
+		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
 			--  or products like mysql-fabric won't work
@@ -38,23 +61,37 @@ if [ "$1" = 'mysqld' ]; then
 		EOSQL
 		
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
+			echo "CREATE DATABASE IF NOT EXISTS \`"$MYSQL_DATABASE"\` ;" >> "$tempSqlFile"
 		fi
 		
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$tempSqlFile"
+			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
 			
 			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$tempSqlFile"
+				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
 			fi
 		fi
 		
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 		
-		set -- "$@" --init-file="$tempSqlFile"
+		chown -R mysql:mysql "$DATADIR"
+		mysql -uroot < $tempSqlFile
+		sed -i -e '/^log-error/d' /etc/my.cnf
+		cat /etc/my.cnf
+		rm -f $tempSqlFile
+		kill $(cat $PIDFILE)
+                for i in $(seq 30 -1 0); do
+		    [ -S $SOCKET ] || break
+		    echo 'MySQL init process in progress...'
+		    sleep 1
+		done
+                if [ $i = 0 ]; then
+                    echo >&2 'MySQL hangs during init process.'
+                    exit 1
+                fi
+		echo 'MySQL init process done. Ready for start up.'
 	fi
-	
-	chown -R mysql:mysql "$DATADIR"
 fi
 
 exec "$@"
+

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -46,10 +46,6 @@ if [ "$1" = 'mysqld' ]; then
 			exit 1
 		fi
 
-		# Workaround for bug in 5.7 that doesn't clean up after itself correctly 
-		rm -f $DATADIR/ib_logfile0
-		rm -f $DATADIR/ib_logfile1
-		rm -f $DATADIR/ibdata1
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -44,6 +44,10 @@ if [ "$1" = 'mysqld' ]; then
                     exit 1
                 fi
                 
+		# Workaround for bug in 5.7 that doesn't clean up after itself correctly 
+		rm -f $DATADIR/ib_logfile0
+		rm -f $DATADIR/ib_logfile1
+		rm -f $DATADIR/ibdata1
 		# These statements _must_ be on individual lines, and _must_ end with
 		# semicolons (no line breaks or comments are permitted).
 		# TODO proper SQL escaping on ALL the things D:
@@ -76,8 +80,6 @@ if [ "$1" = 'mysqld' ]; then
 		
 		chown -R mysql:mysql "$DATADIR"
 		mysql -uroot < $tempSqlFile
-		sed -i -e '/^log-error/d' /etc/my.cnf
-		cat /etc/my.cnf
 		rm -f $tempSqlFile
 		kill $(cat $PIDFILE)
                 for i in $(seq 30 -1 0); do


### PR DESCRIPTION
The first time the server was started, the file containing the root password in plaintext would be readable by any user on the database (and the filename listed in the variable list).

We changed the first run to do the initialization separately, then restart the server.