### PR TITLE
fix: don't replicate local setup

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -18,9 +18,7 @@ if [ "$1" = 'mysqld' ]; then
 		fi
 		
 		echo 'Running mysql_install_db ...'
-		# pass --defaults-file and --defaults-extra-file to mysql_install_db
-		DEFAULTS_FILE_ARGS=$(egrep -o -- '--defaults(|-extra)-file=[^ ]+' <<< "$@")
-		mysql_install_db --datadir="$DATADIR" $DEFAULTS_FILE_ARGS
+		mysql_install_db --datadir="$DATADIR"
 		echo 'Finished mysql_install_db'
 		
 		# These statements _must_ be on individual lines, and _must_ end with

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -29,9 +29,9 @@ if [ "$1" = 'mysqld' ]; then
 		
 		tempSqlFile='/tmp/mysql-first-time.sql'
 		cat > "$tempSqlFile" <<-EOSQL
-		        -- What's done in this file shouldn't be replicated
+			-- What's done in this file shouldn't be replicated
 			--  or products like mysql-fabric won't work
-       			SET @@SESSION.SQL_LOG_BIN=0;
+			SET @@SESSION.SQL_LOG_BIN=0;
 
 			DELETE FROM mysql.user ;
 			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;


### PR DESCRIPTION
The following patch:
 - avoid replicating local user setup to slave hosts;
 - pass --defaults-file to mysql_install_db

