### PR TITLE
Make get_option() handle duplicate options in my_print_defaults output

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -5,7 +5,9 @@ get_option () {
 	local section=$1
 	local option=$2
 	local default=$3
-	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	# my_print_defaults can output duplicates, if an option exists both globally and in
+	# a custom config file. We pick the last occurence, which is from the custom config.
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2- | tail -n1)
 	[ -z $ret ] && ret=$default
 	echo $ret
 }

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -5,7 +5,9 @@ get_option () {
 	local section=$1
 	local option=$2
 	local default=$3
-	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	# my_print_defaults can output duplicates, if an option exists both globally and in
+	# a custom config file. We pick the last occurence, which is from the custom config.
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2- | tail -n1)
 	[ -z $ret ] && ret=$default
 	echo $ret
 }

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -5,7 +5,9 @@ get_option () {
 	local section=$1
 	local option=$2
 	local default=$3
-	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	# my_print_defaults can output duplicates, if an option exists both globally and in
+	# a custom config file. We pick the last occurence, which is from the custom config.
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2- | tail -n1)
 	[ -z $ret ] && ret=$default
 	echo $ret
 }
@@ -77,6 +79,7 @@ if [ "$1" = 'mysqld' ]; then
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
 		mysql -uroot < "$tempSqlFile"
+
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)
 		for i in $(seq 30 -1 0); do
@@ -95,4 +98,3 @@ if [ "$1" = 'mysqld' ]; then
 fi
 
 exec "$@"
-


### PR DESCRIPTION
get_option() was added by #53 to extract `socket` and `pid-file` from my_print_defaults. However if a custom mysql configuration file has been added, my_print_defaults returns duplicates (it merely lists all options specified in any config file and doesn't de-dupe). In these cases, `ret` would equal:
`/var/run/mysqld/mysqld.sock /var/lib/mysql/mysqld.sock`
...causing:
`/entrypoint.sh: line 9: [: /var/run/mysqld/mysqld.sock: binary operator expected`

As such, get_option() should just return the last matching option found in the my_print_defaults output - which should correspond to the one in the custom configuration file (rather than say the global default).

Fixes #74.