### PR TITLE
Prevent mysqld --verbose --help from writing to empty datadir

### DIFF
--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$1" = 'mysqld' ]; then
 	# Get config
-	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+	DATADIR="$("$@" --verbose --help --innodb-read-only 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 	SOCKET=$(get_option  mysqld socket "$DATADIR/mysql.sock")
 	PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
 


### PR DESCRIPTION
From 5.7.6 and on, running mysqld --verbose --help will fully initialize innodb. If datadir is empty and writeable (with the default setup it's not writeable) this will create certain files there, causing the following initialization step to fail.

Using --innodb-read-only prevents this from happening, which should fix issue #69.