### PR TITLE
Specify protocol for client during init

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:wheezy
-
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
@@ -41,13 +40,10 @@ ENV PATH $PATH:/usr/local/mysql/bin:/usr/local/mysql/scripts
 RUN mkdir -p /etc/mysql/conf.d \
 	&& { \
 		echo '[mysqld]'; \
-		echo '!includedir /etc/mysql/conf.d/'; \
-	} > /etc/mysql/my.cnf \
-	&& { \
-		echo '[mysqld]'; \
 		echo 'user = mysql'; \
 		echo 'datadir = /var/lib/mysql'; \
-	} > /etc/mysql/conf.d/docker.cnf
+		echo '!includedir /etc/mysql/conf.d/'; \
+	} > /etc/mysql/my.cnf
 
 VOLUME /var/lib/mysql
 

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -79,7 +79,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < "$tempSqlFile"
+		mysql --protocol=socket -uroot < "$tempSqlFile"
 
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -78,7 +78,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < "$tempSqlFile"
+		mysql --protocol=socket -uroot < "$tempSqlFile"
 
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -78,7 +78,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 
-		mysql -uroot < "$tempSqlFile"
+		mysql --protocol=socket -uroot < "$tempSqlFile"
 
 		rm -f "$tempSqlFile"
 		kill $(cat $PIDFILE)


### PR DESCRIPTION
Image init can fail if user specifies a custom config with a changed socket setting (e.g. setting it to tcp) as mentioned in issue #83.
There's also a related problem in that the 5.5 image stores the default settings in a folder that will be overriden by the suggested method for providing a custom config (https://github.com/docker-library/docs/tree/master/mysql#user-content-using-a-custom-mysql-configuration-file).

Fixes #83