### PR TITLE
Embed the full Debian package version number and fix the 5.7 build

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y perl --no-install-recommends && rm -rf 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
 ENV MYSQL_MAJOR 5.6
-ENV MYSQL_VERSION 5.6.27
+ENV MYSQL_VERSION 5.6.27-1debian8
 
 RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 
@@ -28,7 +28,7 @@ RUN { \
 		echo mysql-community-server mysql-community-server/re-root-pass password ''; \
 		echo mysql-community-server mysql-community-server/remove-test-db select false; \
 	} | debconf-set-selections \
-	&& apt-get update && apt-get install -y mysql-server="${MYSQL_VERSION}"* && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y mysql-server="${MYSQL_VERSION}" && rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
 
 # comment out a few problematic configuration values

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get install -y perl --no-install-recommends && rm -rf 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
 ENV MYSQL_MAJOR 5.7
-ENV MYSQL_VERSION 5.7.9
+ENV MYSQL_VERSION 5.7.9-1debian8
 
-RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}-dmr" > /etc/apt/sources.list.d/mysql.list
+RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
@@ -28,7 +28,7 @@ RUN { \
 		echo mysql-community-server mysql-community-server/re-root-pass password ''; \
 		echo mysql-community-server mysql-community-server/remove-test-db select false; \
 	} | debconf-set-selections \
-	&& apt-get update && apt-get install -y mysql-server="${MYSQL_VERSION}"* && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y mysql-server="${MYSQL_VERSION}" && rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
 
 # comment out a few problematic configuration values

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -17,6 +17,7 @@ echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
 for version in "${versions[@]}"; do
 	commit="$(cd "$version" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
 	fullVersion="$(grep -m1 'ENV MYSQL_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
+	fullVersion="${fullVersion%-*}" # remove "debian version" suffix
 	versionAliases=()
 	while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
 		versionAliases+=( $fullVersion )

--- a/update.sh
+++ b/update.sh
@@ -10,10 +10,14 @@ fi
 versions=( "${versions[@]%/}" )
 
 for version in "${versions[@]}"; do
-	fullVersion="$(curl -sSL "https://dev.mysql.com/downloads/mysql/$version.html?os=2" \
-		| grep '">(mysql-'"$version"'.*-linux.*-x86_64\.tar\.gz)<' \
-		| sed -r 's!.*\(mysql-([^<)]+)-linux.*-x86_64\.tar\.gz\).*!\1!' \
-		| sort -V | tail -1)"
+	if [ "$version" = '5.5' ]; then
+		fullVersion="$(curl -sSL "https://dev.mysql.com/downloads/mysql/$version.html?os=2" \
+			| grep '">(mysql-'"$version"'.*-linux.*-x86_64\.tar\.gz)<' \
+			| sed -r 's!.*\(mysql-([^<)]+)-linux.*-x86_64\.tar\.gz\).*!\1!' \
+			| sort -V | tail -1)"
+	else
+		fullVersion="$(curl -fsSL "http://repo.mysql.com/apt/debian/dists/jessie/mysql-$version/binary-amd64/Packages.gz" | gunzip | awk -F ': ' '$1 == "Package" { pkg = $2; next } pkg == "mysql-server" && $1 == "Version" { print $2 }')"
+	fi
 	
 	(
 		set -x


### PR DESCRIPTION
This fixes the issue in https://github.com/docker-library/mysql/commit/617c6470dfd96839a697d262eafef5242b9ea492#commitcomment-13911981 and https://travis-ci.org/docker-library/mysql/jobs/86708981#L245-L262, and gives us more resilient+consistent builds overall.