### PR TITLE
Removed --innodb-read-only workaround for fixed server bug

### DIFF
--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 if [ "$1" = 'mysqld' ]; then
 	# Get config
-	DATADIR="$("$@" --verbose --help --innodb-read-only 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
 	if [ ! -d "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then


### PR DESCRIPTION
The option was added as a workaround for a server bug that caused file locks in datadir when
mysqld --verbose --help is run. The bug has been fixed, so the workaround is no longer needed.

MySQL bug: http://bugs.mysql.com/bug.php?id=75995