### PR TITLE
Exit gracefully on ctrl-C

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -100,4 +100,12 @@ if [ "$1" = 'mysqld' ]; then
 	chown -R mysql:mysql "$DATADIR"
 fi
 
-exec "$@"
+"$@" &
+pid="$!"
+trap "echo 'Stopping MySQL, PID $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+
+# A signal emitted while waiting will make the wait command return code > 128
+# Let's wrap it in a loop that doesn't end before the process is indeed stopped
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -100,4 +100,12 @@ if [ "$1" = 'mysqld' ]; then
 	chown -R mysql:mysql "$DATADIR"
 fi
 
-exec "$@"
+"$@" &
+pid="$!"
+trap "echo 'Stopping MySQL, PID $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+
+# A signal emitted while waiting will make the wait command return code > 128
+# Let's wrap it in a loop that doesn't end before the process is indeed stopped
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -100,4 +100,12 @@ if [ "$1" = 'mysqld' ]; then
 	chown -R mysql:mysql "$DATADIR"
 fi
 
-exec "$@"
+"$@" &
+pid="$!"
+trap "echo 'Stopping MySQL, PID $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+
+# A signal emitted while waiting will make the wait command return code > 128
+# Let's wrap it in a loop that doesn't end before the process is indeed stopped
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done


### PR DESCRIPTION
When mysql is run in interactive mode, with the following command line, I can't stop it by hitting `ctrl-c`.

```
docker run --rm -it -e MYSQL_ROOT_PASSWORD=a mysql:latest
```
The two ways I found to stop it were:

* `docker kill`
* Creating my own Dockerfile that wraps the entrypoint in a bash script that handles SIGINT as can be seen in my fix.

I think this fix can be merged in the official release. Please let me know if this has unwanted side-effects...