### PR TITLE
Fixes #99

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql && useradd -u 1000 -r -g mysql mysql
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql && useradd -u 1000 -r -g mysql mysql
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r mysql && useradd -u 1000 -r -g mysql mysql
 
 RUN mkdir /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
`docker-machine` and `boot2docker` in OS X with VirtualBox as backend
mounts vboxsf as UID=1000, GID=50, so user with UID=1000 will have permissions
to write to the data volume mounted as `-v /Users/somebody/mysqldata:/var/lib/mysql`
for example.

For details see:
- https://github.com/boot2docker/boot2docker/issues/581
- https://github.com/boot2docker/boot2docker/issues/587#issuecomment-114868208
- https://github.com/docker/machine/issues/2660#issuecomment-167629938