### PR TITLE
Update a few minor bits for consistency and proper failure

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
@@ -16,6 +16,7 @@ if [ "$1" = 'mysqld' ]; then
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
 			exit 1
 		fi
+
 		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 
@@ -84,8 +85,8 @@ if [ "$1" = 'mysqld' ]; then
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
-				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f" && echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}" && echo ;;
+				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
+				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo


### PR DESCRIPTION
1. whitespace
2. replace `&&` with `;` to ensure `set -e` Does The Right Thing (see https://www.gnu.org/software/bash/manual/bashref.html#index-set, especially the bit under `-e` about "part of any command executed in a && or || list except the command following the final && or ||")
3. add a simple warning for 5.5 + `MYSQL_ONETIME_PASSWORD` (`PASSWORD EXPIRE` unsupported)

```diff
diff --git a/5.7/docker-entrypoint.sh b/5.6/docker-entrypoint.sh
index 025638a..77feab0 100755
--- a/5.7/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'mysqld' ]; then
 		chown -R mysql:mysql "$DATADIR"

 		echo 'Initializing database'
-		"$@" --initialize-insecure
+		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --keep-my-cnf
 		echo 'Database initialized'

 		"$@" --skip-networking &
```

```diff
diff --git a/5.6/docker-entrypoint.sh b/5.5/docker-entrypoint.sh
index 77feab0..1313cd5 100755
--- a/5.6/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -21,10 +21,10 @@ if [ "$1" = 'mysqld' ]; then
 		chown -R mysql:mysql "$DATADIR"

 		echo 'Initializing database'
-		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --keep-my-cnf
+		mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --basedir=/usr/local/mysql
 		echo 'Database initialized'

-		"$@" --skip-networking &
+		"$@" --skip-networking --basedir=/usr/local/mysql &
 		pid="$!"

 		mysql=( mysql --protocol=socket -uroot )
@@ -93,9 +93,9 @@ if [ "$1" = 'mysqld' ]; then
 		done

 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
-			"${mysql[@]}" <<-EOSQL
-				ALTER USER 'root'@'%' PASSWORD EXPIRE;
-			EOSQL
+			echo >&2
+			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'
+			echo >&2
 		fi
 		if ! kill -s TERM "$pid" || ! wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
```

cc @ltangvald