### PR TITLE
kill return zero, but wait return TERM exit code (143)

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'
 			echo >&2
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'
 			echo >&2
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi


### PR DESCRIPTION
```
#!/bin/bash

sleep 5 &
pid=$!

echo "PID:" $pid
kill -s TERM "$pid"
echo "KILL EXIT: $?"
wait "$pid"
echo "WAIT EXIT: $?"

#if ! kill -s TERM "$pid" || wait "$pid"; then
#    echo "FAIL: $?"
#    exit $?
#fi

echo "OK: $?"
```

```
root@docker01:~# ./1.sh
PID: 29685
KILL EXIT: 0
./1.sh: line 9: 29685 Terminated              sleep 5
WAIT EXIT: 143
OK: 0

root@docker01:~#
```