### PR TITLE
If n is not given, the command waits until all jobs known to the invoking shell have terminated.

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'
 			echo >&2
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'
 			echo >&2
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		if ! kill -s TERM "$pid" || wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -108,7 +108,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;
 			EOSQL
 		fi
-		if ! kill -s TERM "$pid" || wait "$pid"; then
+		if ! kill -s TERM "$pid" || ! wait; then
 			echo >&2 'MySQL init process failed.'
 			exit 1
 		fi


### PR DESCRIPTION
For better compatibility, wait for all child.
