### PR TITLE
Update Dockerfile to modify correct config file

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -50,9 +50,9 @@ RUN { \
 
 # comment out a few problematic configuration values
 # don't reverse lookup hostnames, they are usually another container
-RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
-	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
-	&& mv /tmp/my.cnf /etc/mysql/my.cnf
+RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/mysql.conf.d/mysqld.cnf \
+	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/mysql.conf.d/mysqld.cnf > /tmp/mysqld.cnf \
+	&& mv /tmp/mysqld.cnf /etc/mysql/mysql.conf.d/mysqld.cnf
 
 VOLUME /var/lib/mysql
 


### PR DESCRIPTION
MySQL 5.7.14 changed the structure of the configuration directory, so
/etc/mysql/my.cnf no longer contains the config options, but only includes other directories.
This caused the modification done to the config in Dockerfile to fail silently, creating issues
with any setups that required those changes, such as running with a different user.
Changed script to modify the new file /etc/mysql/mysql.conf.d/mysqld.cnf

Fixes issue #197