### PR TITLE
Handle Empty initdb.d directory

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+shopt -s nullglob
 
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+shopt -s nullglob
 
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+shopt -s nullglob
 
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then


### PR DESCRIPTION
The docker-entrypoint.sh script does not currently handle the case where
the docker-entrypoint-initdb.d directory is empty. This commit sets the
nullglob shell option to cause the empty directory to glob to nothing.

This change will fix the following confusing message from coming up
during startup.

```
/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
```