### PR TITLE
Allow override of DATADIR for database init

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -19,7 +19,11 @@ for arg; do
 done
 
 _datadir() {
-	"$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   if [ -z ${DATADIR+x} ]; then
+      "$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   else
+      echo $DATADIR
+   fi
 }
 
 # allow the container to be started with `--user`

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -19,7 +19,11 @@ for arg; do
 done
 
 _datadir() {
-	"$@" --verbose --help --log-bin-index=`mktemp -u` 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   if [ -z ${DATADIR+x} ]; then
+      "$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   else
+      echo $DATADIR
+   fi
 }
 
 # allow the container to be started with `--user`

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -19,7 +19,11 @@ for arg; do
 done
 
 _datadir() {
-	"$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   if [ -z ${DATADIR+x} ]; then
+      "$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+   else
+      echo $DATADIR
+   fi
 }
 
 # allow the container to be started with `--user`


### PR DESCRIPTION
This represents what I view as a minimally-invasive solution to #207 

A more "complete" solution would add a `--datadir` argument to the execution if there is not already one AND `DATADIR` is set to something other than the default, but this modification simply makes it _possible_ to use this container, unmodified, with a non-default data directory.

Examples:

Preserve the status quo:

```
~/c/p/m/5.7 (allow-datadir-overrride) $ docker run --rm --name=statusquo -e MYSQL_ROOT_PASSWORD=testme mysql:test
Initializing database
Database initialized
MySQL init process in progress...
Warning: Unable to load '/usr/share/zoneinfo/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/posix/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/right/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.


MySQL init process done. Ready for start up.

```

Check:

```
~/c/p/m/5.7 (allow-datadir-overrride) $ docker exec -it statusquo ls -l /var/lib/mysql
total 188424
-rw-r----- 1 mysql mysql       56 Sep  3 17:56 auto.cnf
-rw-r----- 1 mysql mysql     1329 Sep  3 17:56 ib_buffer_pool
-rw-r----- 1 mysql mysql 50331648 Sep  3 17:56 ib_logfile0
-rw-r----- 1 mysql mysql 50331648 Sep  3 17:56 ib_logfile1
-rw-r----- 1 mysql mysql 79691776 Sep  3 17:56 ibdata1
-rw-r----- 1 mysql mysql 12582912 Sep  3 17:56 ibtmp1
drwxr-x--- 1 mysql mysql     2298 Sep  3 17:56 mysql
drwxr-x--- 1 mysql mysql     5638 Sep  3 17:56 performance_schema
drwxr-x--- 1 mysql mysql     6656 Sep  3 17:56 sys
```

Non-default data directory:

```
~/c/p/m/5.7 (allow-datadir-overrride) $ docker run --rm --name=nondefault -e MYSQL_ROOT_PASSWORD=testme -e DATADIR=/data/mysql -v /tmp/mysql:/data mysql:test --datadir=/data/mysql
Initializing database
Database initialized
MySQL init process in progress...
Warning: Unable to load '/usr/share/zoneinfo/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/posix/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/right/Factory' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.


MySQL init process done. Ready for start up.

```

Check:

```
~/c/p/m/5.7 (allow-datadir-overrride) $ docker exec -it nondefault ls -l /var/lib/mysql
total 0
~/c/p/m/5.7 (allow-datadir-overrride) $ docker exec -it nondefault ls -l /data/mysql
total 188968
-rw-r----- 1 mysql mysql       56 Sep  3 17:59 auto.cnf
-rw-r----- 1 mysql mysql     1329 Sep  3 17:59 ib_buffer_pool
-rw-r----- 1 mysql mysql 50331648 Sep  3 17:59 ib_logfile0
-rw-r----- 1 mysql mysql 50331648 Sep  3 17:59 ib_logfile1
-rw-r----- 1 mysql mysql 79691776 Sep  3 17:59 ibdata1
-rw-r----- 1 mysql mysql 12582912 Sep  3 17:59 ibtmp1
drwxr-x--- 1 mysql mysql     2298 Sep  3 17:59 mysql
drwxr-x--- 1 mysql mysql     5638 Sep  3 17:59 performance_schema
drwxr-x--- 1 mysql mysql     6656 Sep  3 17:59 sys
```
