### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -122,7 +122,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
+		for f in $(find /docker-entrypoint-initdb.d/ -type f | sort); do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
 				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;


### PR DESCRIPTION
Changed file glob to find command. This will allow nested directories which provides greater flexibility when building images. For instance, I'm inserting a SQL file on build to create an initial set of users. Then, before the first run, the user can mount extra SQL files to seed data in. The problem is if the user's SQL files are mounted at /docker-entrypoint-initdb.d then my user initializing SQL created on build is mashed by the new mount. With this change I can mount my default SQL in /docker-entrypoint-initdb.d/00-base and other sql can be mounted in /docker-entrypoint-initdb.d/01-extra and have all SQL ran on first run.