### PR TITLE
Hardcode socket path for temporary init runs of server and client

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -64,10 +64,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mysql_install_db --datadir="$DATADIR" --rpm --basedir=/usr/local/mysql
 		echo 'Database initialized'
 
-		"$@" --skip-networking --basedir=/usr/local/mysql &
+		"$@" --skip-networking --basedir=/usr/local/mysql --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost)
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock)
 
 		for i in {30..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -64,10 +64,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf
 		echo 'Database initialized'
 
-		"$@" --skip-networking &
+		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost)
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock)
 
 		for i in {30..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -64,10 +64,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --initialize-insecure
 		echo 'Database initialized'
 
-		"$@" --skip-networking &
+		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost)
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock)
 
 		for i in {30..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -64,10 +64,10 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --initialize-insecure
 		echo 'Database initialized'
 
-		"$@" --skip-networking &
+		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost)
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock)
 
 		for i in {30..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then


### PR DESCRIPTION
During container init, we start both server and client temporarily,
for user admin etc. For the server we pass on any command line
arguments specified by the user, but for the client we don't. This
can cause an issue if the user specifies a different socket path,
since the client won't find it, causing init failure. Since the
socket location doesn't really matter for these temporary runs, we
hardcode it to /var/run/mysqld/mysqld.sock
Fixes issue #238