### PR TITLE
Add "openssl" and invoke "mysql_ssl_rsa_setup" at runtime so that automatic SSL works the same as the MySQL packages

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -19,12 +19,18 @@ RUN set -x \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+# for MYSQL_RANDOM_ROOT_PASSWORD
+		pwgen \
+# for mysql_ssl_rsa_setup
+		openssl \
 # FATAL ERROR: please install the following Perl modules before executing /usr/local/mysql/scripts/mysql_install_db:
 # File::Basename
 # File::Copy
 # Sys::Hostname
 # Data::Dumper
-RUN apt-get update && apt-get install -y perl pwgen --no-install-recommends && rm -rf /var/lib/apt/lists/*
+		perl \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -ex; \
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -87,6 +87,13 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --initialize-insecure
 		echo 'Database initialized'
 
+		if command -v mysql_ssl_rsa_setup > /dev/null && [ ! -e "$DATADIR/server-key.pem" ]; then
+			# https://github.com/mysql/mysql-server/blob/23032807537d8dd8ee4ec1c4d40f0633cd4e12f9/packaging/deb-in/extra/mysql-systemd-start#L81-L84
+			echo 'Initializing certificates'
+			mysql_ssl_rsa_setup --datadir="$DATADIR"
+			echo 'Certificates initialized'
+		fi
+
 		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -19,12 +19,18 @@ RUN set -x \
 
 RUN mkdir /docker-entrypoint-initdb.d
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+# for MYSQL_RANDOM_ROOT_PASSWORD
+		pwgen \
+# for mysql_ssl_rsa_setup
+		openssl \
 # FATAL ERROR: please install the following Perl modules before executing /usr/local/mysql/scripts/mysql_install_db:
 # File::Basename
 # File::Copy
 # Sys::Hostname
 # Data::Dumper
-RUN apt-get update && apt-get install -y perl pwgen --no-install-recommends && rm -rf /var/lib/apt/lists/*
+		perl \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -ex; \
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -87,6 +87,13 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --initialize-insecure
 		echo 'Database initialized'
 
+		if command -v mysql_ssl_rsa_setup > /dev/null && [ ! -e "$DATADIR/server-key.pem" ]; then
+			# https://github.com/mysql/mysql-server/blob/23032807537d8dd8ee4ec1c4d40f0633cd4e12f9/packaging/deb-in/extra/mysql-systemd-start#L81-L84
+			echo 'Initializing certificates'
+			mysql_ssl_rsa_setup --datadir="$DATADIR"
+			echo 'Certificates initialized'
+		fi
+
 		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
 		pid="$!"
 


### PR DESCRIPTION
Fixes #257

cc @ltangvald

I verified this by building/running with no extra flags, then connecting from a separate container using `--ssl-mode REQUIRED` (to force SSL communications). :+1: