### PR TITLE
Fix behavior during initialization timeout

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -97,7 +97,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
-		for i in {30..0}; do
+		for i in $(seq ${MYSQL_START_TIMEOUT:-30} -1 0); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
@@ -105,7 +105,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
+			echo >&2 'MySQL init process failed. Cleaning up..'
+			rm -rf $DATADIR/mysql
 			exit 1
 		fi
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -97,15 +97,16 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
-		for i in {30..0}; do
+		for i in $(seq ${MYSQL_START_TIMEOUT:-30} -1 0); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
-			echo 'MySQL init process in progress...'
+			echo "MySQL init process in progress..."
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
+			echo >&2 'MySQL init process failed. Cleaning up..'
+			rm -rf $DATADIR/mysql
 			exit 1
 		fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -104,7 +104,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
-		for i in {30..0}; do
+		for i in $(seq ${MYSQL_START_TIMEOUT:-30} -1 0); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
@@ -112,7 +112,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
+			echo >&2 'MySQL init process failed. Cleaning up..'
+			rm -rf $DATADIR/mysql
 			exit 1
 		fi
 

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -104,7 +104,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
-		for i in {30..0}; do
+		for i in $(seq ${MYSQL_START_TIMEOUT:-30} -1 0); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
@@ -112,7 +112,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
+			echo >&2 'MySQL init process failed. Cleaning up..'
+			rm -rf $DATADIR/mysql
 			exit 1
 		fi
 


### PR DESCRIPTION
Add configurable timeout for MySQL start during initialization. On timeout, remove datadir to allow new initialization try on next container creation. Otherwise mysql will end up in empty unconfigured state without root password set, etc.

Better fix for: https://github.com/docker-library/mysql/pull/159