### PR TITLE
docker-entrypoint.sh permissions fix

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -62,7 +62,9 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+
+RUN chmod 777 /usr/local/bin/docker-entrypoint.sh && ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306


### PR DESCRIPTION
"exec: \"docker-entrypoint.sh\": executable file not found in $PATH".