### PR TITLE
Set permissions on log folder

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -65,9 +65,15 @@ _get_config() {
 # allow the container to be started with `--user`
 if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
+
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
 	chown -R mysql:mysql "$DATADIR"
+
+	file_env 'MYSQL_LOG_DIR' '/var/log/mysql'
+	mkdir -p "$MYSQL_LOG_DIR"
+	chown -R mysql:mysql "$MYSQL_LOG_DIR"
+
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -65,9 +65,15 @@ _get_config() {
 # allow the container to be started with `--user`
 if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
+
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
 	chown -R mysql:mysql "$DATADIR"
+
+	file_env 'MYSQL_LOG_DIR' '/var/log/mysql'
+	mkdir -p "$MYSQL_LOG_DIR"
+	chown -R mysql:mysql "$MYSQL_LOG_DIR"
+
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -65,9 +65,15 @@ _get_config() {
 # allow the container to be started with `--user`
 if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
+
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
 	chown -R mysql:mysql "$DATADIR"
+
+	file_env 'MYSQL_LOG_DIR' '/var/log/mysql'
+	mkdir -p "$MYSQL_LOG_DIR"
+	chown -R mysql:mysql "$MYSQL_LOG_DIR"
+
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -65,9 +65,15 @@ _get_config() {
 # allow the container to be started with `--user`
 if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
+
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
 	chown -R mysql:mysql "$DATADIR"
+
+	file_env 'MYSQL_LOG_DIR' '/var/log/mysql'
+	mkdir -p "$MYSQL_LOG_DIR"
+	chown -R mysql:mysql "$MYSQL_LOG_DIR"
+
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
Fixes #146

Currently no permissions are set for MySQL's log folder, resulting in an error. The primary obstacle fixing it is, that we can't solve it with `_get_config`, because `log-error` returns `stderr` instead of the actual folder. One solution could be to use the `mysqladmin variables` command, but it requires a `root` login, which doesn't seem too comfortable.
For this patch I have chosen a lighter solution without any impact on current set-ups: very simply, the log folder can be passed as an environment variable, the same way as `MYSQL_ROOT_PASSWORD` and the other variables (if not set, we'll use `var/log/mysql`, because it's the default).

If requested, I can work on improving the solution by querying the log folder with `mysqladmin`. I'm not sure if we can always count on getting the root credentials, or if executing this command has any side effect, like a log entry, affecting currently running admin sessions, or anything.