### PR TITLE
Update 8.0 to Debian Stretch

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,6 +1,9 @@
-FROM debian:jessie
+FROM debian:stretch-slim
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*
 
 # add gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
@@ -41,9 +44,9 @@ RUN set -ex; \
 	apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.3-rc-1debian8
+ENV MYSQL_VERSION 8.0.4-rc-1debian9
 
-RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
+RUN echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter

--- a/update.sh
+++ b/update.sh
@@ -9,21 +9,45 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
+defaultDebianVariant='stretch-slim'
+declare -A debianVariants=(
+	[5.5]='jessie'
+	[5.6]='jessie'
+	[5.7]='jessie'
+)
+
 for version in "${versions[@]}"; do
+	debianVariant="${debianVariants[$version]:-$defaultDebianVariant}"
+	debianSuite="${debianVariant%%-*}" # "stretch", etc
+
 	if [ "$version" = '5.5' ]; then
 		fullVersion="$(curl -sSL "https://dev.mysql.com/downloads/mysql/$version.html?os=2" \
 			| grep '">(mysql-'"$version"'.*-linux.*-x86_64\.tar\.gz)<' \
 			| sed -r 's!.*\(mysql-([^<)]+)-linux.*-x86_64\.tar\.gz\).*!\1!' \
 			| sort -V | tail -1)"
 	else
-		fullVersion="$(curl -fsSL "http://repo.mysql.com/apt/debian/dists/jessie/mysql-$version/binary-amd64/Packages.gz" | gunzip | awk -F ': ' '$1 == "Package" { pkg = $2; next } pkg == "mysql-server" && $1 == "Version" { print $2 }')"
+		fullVersion="$(
+			curl -fsSL "http://repo.mysql.com/apt/debian/dists/$debianSuite/mysql-$version/binary-amd64/Packages.gz" \
+				| gunzip \
+				| awk -F ': ' '
+					$1 == "Package" {
+						pkg = $2
+						next
+					}
+					pkg == "mysql-server" && $1 == "Version" {
+						print $2
+					}
+				'
+		)"
 	fi
-	
+
 	(
 		set -x
-		sed -ri '
-			s/^(ENV MYSQL_MAJOR) .*/\1 '"$version"'/;
-			s/^(ENV MYSQL_VERSION) .*/\1 '"$fullVersion"'/
-		' "$version/Dockerfile"
+		sed -ri \
+			-e 's/^(ENV MYSQL_VERSION) .*/\1 '"$fullVersion"'/' \
+			-e 's/^(ENV MYSQL_MAJOR) .*/\1 '"$version"'/' \
+			-e 's/^(FROM) .*/\1 debian:'"$debianVariant"'/' \
+			-e 's!(http://repo.mysql.com/apt/debian/) [^ ]+!\1 '"$debianSuite"'!' \
+			"$version/Dockerfile"
 	)
 done


### PR DESCRIPTION
Closes #375
Closes #367

This should be reasonably safe to do given that 8.0 is still in pre-release stages.

It looks like we should also consider updating both 5.6 and 5.7 to Stretch, but I didn't want to rock that boat in the same breath as getting 8.0.4 out. :smile: