### PR TITLE
More comprehensive logs during mysql initialization

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -99,10 +99,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
 		for i in {30..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+			echo 'Trying to connect to mysql...'
+			if echo 'SELECT 1' | "${mysql[@]}" > /dev/null; then
 				break
 			fi
-			echo 'MySQL init process in progress...'
+			echo 'MySQL init process must be in progress...'
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -99,10 +99,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
 		for i in {30..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+			echo 'Trying to connect to mysql...'
+			if echo 'SELECT 1' | "${mysql[@]}" > /dev/null; then
 				break
 			fi
-			echo 'MySQL init process in progress...'
+			echo 'MySQL init process must be in progress...'
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -105,10 +105,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
 
 		for i in {30..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+			echo 'Trying to connect to mysql...'
+			if echo 'SELECT 1' | "${mysql[@]}" > /dev/null; then
 				break
 			fi
-			echo 'MySQL init process in progress...'
+			echo 'MySQL init process must be in progress...'
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then


### PR DESCRIPTION
More comprehensive logs during mysql initialization and also visible error messages.
The idea came when I faced a problem with initialization of magento:
```
mysql                      | 2018-02-28T09:41:21.166088090Z 2018-02-28T09:41:21.166046Z 0 [Note] mysqld: ready for connections.
mysql                      | 2018-02-28T09:41:21.166104229Z Version: '5.7.21'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server (GPL)
mysql                      | 2018-02-28T09:41:21.921672269Z MySQL init process in progress...
mysql                      | 2018-02-28T09:41:22.932179525Z MySQL init process in progress...
.
.
.
mysql                      | 2018-02-28T09:41:51.203276913Z MySQL init process in progress...
mysql                      | 2018-02-28T09:41:52.206185839Z MySQL init process failed.

```
There were two solutions on the internet to remove MYSQL_HOST from environment variables and to remove memory limit for docker container both of which was not the case for me. I read through the init script to realize that it tries to send a simple select 1 to the mysql and if it fails it thinks the mysql is still initializing. So continues to retry. When I tried the same select command manually:
```
echo 'SELECT 1' | mysql --protocol-=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock
mysql: [ERROR] unknown variable 'character_set_client=utf8'
```
I just realized that it's an error with my config file. So far so good. But:
**Isn't it better for the init script to show the actual error message of mysql when it is retrying?**
This feature can save hours of frustration for developers. That is why I prepared this pull request.