### PR TITLE
move init-file processing into a function

### DIFF
--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -40,6 +40,24 @@ file_env() {
 	unset "$fileVar"
 }
 
+# usage: process_init_file FILENAME MYSQLCOMMAND...
+#    ie: process_init_file foo.sh mysql -uroot
+# (process a single initializer file, based on its extension. we define this
+# function here, so that initializer scripts (*.sh) can use the same logic,
+# potentially recursively, or override the logic used in subsequent calls)
+process_init_file() {
+	local f="$1"; shift
+	local mysql=( "$@" )
+
+	case "$f" in
+		*.sh)     echo "$0: running $f"; . "$f" ;;
+		*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
+		*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
+		*)        echo "$0: ignoring $f" ;;
+	esac
+	echo
+}
+
 _check_config() {
 	toRun=( "$@" --verbose --help )
 	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
@@ -174,13 +192,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)     echo "$0: running $f"; . "$f" ;;
-				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
+			process_init_file "$f" "${mysql[@]}"
 		done
 
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -40,6 +40,24 @@ file_env() {
 	unset "$fileVar"
 }
 
+# usage: process_init_file FILENAME MYSQLCOMMAND...
+#    ie: process_init_file foo.sh mysql -uroot
+# (process a single initializer file, based on its extension. we define this
+# function here, so that initializer scripts (*.sh) can use the same logic,
+# potentially recursively, or override the logic used in subsequent calls)
+process_init_file() {
+	local f="$1"; shift
+	local mysql=( "$@" )
+
+	case "$f" in
+		*.sh)     echo "$0: running $f"; . "$f" ;;
+		*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
+		*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
+		*)        echo "$0: ignoring $f" ;;
+	esac
+	echo
+}
+
 _check_config() {
 	toRun=( "$@" --verbose --help )
 	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
@@ -174,13 +192,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)     echo "$0: running $f"; . "$f" ;;
-				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
+			process_init_file "$f" "${mysql[@]}"
 		done
 
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then


### PR DESCRIPTION
I have often found myself deriving the mysql image in order to make
it easier to process initialisation files in multiple paths, or to change
the rules used for processing such initialisation files. After having
made such extensions repeatedly, I have now attempted to clean
them up and make them generic enough for inclusion into the
upstream repository.

files found within /docker-entrypoint-initdb.d/* are processed using
specific rules based on their filename. It was previously difficult to
re-use this logic recursively, or to add logic for handling additional
filetypes.

By moving this logic into a shell function, we both enable inner shell
scripts to easily re-use the same logic (for example, for including
files from additional directories or sub-directories), and the
possibility of overriding these processing rules entirely, for example
to enable handling of additional filename patterns.

There is a potential change of functionality compared to the previous
version: the mysql command can no-longer be overridden by changing the
mysql variable. Instead, the mysql command may be overridden only by
overriding the process_init_file() function.

There is a potentially loss of functionality in that included scripts
can no-longer use "break" to escape the file loop. There is presently
no work-around for this, as this is not expected to have been an
intended feature.