### PR TITLE
Add MYSQL_INIT_ONLY var to exit after init

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -200,6 +200,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
+		if [ "$MYSQL_INIT_ONLY" ]; then
+			echo 'MySQL init process done. Exiting.'
+			exit 0
+		fi
+
 		echo
 		echo 'MySQL init process done. Ready for start up.'
 		echo

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -200,6 +200,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
+		if [ "$MYSQL_INIT_ONLY" ]; then
+			echo 'MySQL init process done. Exiting.'
+			exit 0
+		fi
+
 		echo
 		echo 'MySQL init process done. Ready for start up.'
 		echo

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -205,6 +205,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
+		if [ "$MYSQL_INIT_ONLY" ]; then
+			echo 'MySQL init process done. Exiting.'
+			exit 0
+		fi
+
 		echo
 		echo 'MySQL init process done. Ready for start up.'
 		echo

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -207,6 +207,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
+		if [ "$MYSQL_INIT_ONLY" ]; then
+			echo 'MySQL init process done. Exiting.'
+			exit 0
+		fi
+
 		echo
 		echo 'MySQL init process done. Ready for start up.'
 		echo


### PR DESCRIPTION
One of the things I use the mysql image for is bind-mounting a dump into `/docker-entrypoint-initdb.d/` to restore a database. The database restore happens, mysql starts up, and everything is happy. However, I usually don't want to leave the dump bind-mounted into the container permanently. Once the database has been restored, I often want to stop the container, remove the dump file, and then worry about the full deployment of the service at some later stage.

However, the current `docker-entrypoint.sh` always starts mysql after the init process. If we perform a database restore as part of the init, there isn't anything to signal when a restore is complete so that the container can be shut down. So my workaround up until now has been to also bind-mount a shell script to run after the database restore. (The "signal" can be just touching the file `/var/lib/mysql/restore.done`, for example. When the file exists, our orchestration stuff knows the database has been restored and can stop/rm the container.)

This change skirts the whole issue by providing a way to tell the container to exit once all initialization is done. If there's some other less obvious way to do the same thing, I'm all ears as I haven't seen it yet.

I will submit a PR to update the docs if consensus is that this isn't a stupid idea.

If this is accepted, I will likely propose the same feature for the mariadb and postgres images as well.