### PR TITLE
seed scripts not readable by effective user mysql when mounted volume

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -72,7 +72,7 @@ VOLUME /var/lib/mysql
 
 WORKDIR /usr/local/bin
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+RUN ln -s /usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 EXPOSE 3306

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -71,7 +71,8 @@ RUN { \
 VOLUME /var/lib/mysql
 
 WORKDIR /usr/local/bin
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY ./docker-entrypoint.sh .
+RUN chmod 0755 ./docker-entrypoint.sh
 RUN ln -s /usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["./docker-entrypoint.sh"]
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -38,7 +38,14 @@ RUN set -ex; \
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 	key='A4A9406876FCBD3C456770C88C718D3B5072E1F5'; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	for keyserver in $(shuf -e \
+			ha.pool.sks-keyservers.net \
+			hkp://p80.pool.sks-keyservers.net:80 \
+			keyserver.ubuntu.com \
+			hkp://keyserver.ubuntu.com:80 \
+			pgp.mit.edu) ; do \
+		gpg --keyserver $keyserver --recv-keys "$key" && break || true ; \
+	done && \
 	gpg --export "$key" > /etc/apt/trusted.gpg.d/mysql.gpg; \
 	rm -rf "$GNUPGHOME"; \
 	apt-key list > /dev/null

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -70,9 +70,10 @@ RUN { \
 
 VOLUME /var/lib/mysql
 
+WORKDIR /usr/local/bin
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -86,9 +86,9 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	DATADIR="$(_get_config 'datadir' "$@")"
 	# seed scripts from a copy of the initdb.d dir because EID mysql may not have permission to read
 	# a docker volume mounted on the usual initdb.d path
-	mkdir -p "$DATADIR" /etc/mysql/initdb.d
+	mkdir -p "$DATADIR" /etc/mysql/initdb.d/
 	cp -RT /docker-entrypoint-initdb.d /etc/mysql/initdb.d
-	chown -R mysql:mysql "$DATADIR" /etc/mysql/initdb.d
+	chown -R mysql:mysql "$DATADIR" /etc/mysql/initdb.d/
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -84,8 +84,11 @@ _get_config() {
 if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
 	DATADIR="$(_get_config 'datadir' "$@")"
-	mkdir -p "$DATADIR"
-	chown -R mysql:mysql "$DATADIR" /docker-entrypoint-initdb.d/
+	# seed scripts from a copy of the initdb.d dir because EID mysql may not have permission to read
+	# a docker volume mounted on the usual initdb.d path
+	mkdir -p "$DATADIR" /etc/mysql/initdb.d
+	cp -RT /docker-entrypoint-initdb.d /etc/mysql/initdb.d
+	chown -R mysql:mysql "$DATADIR" /etc/mysql/initdb.d
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 
@@ -191,7 +194,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
+		for f in /etc/mysql/initdb.d/*; do
 			process_init_file "$f" "${mysql[@]}"
 		done
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	# Get config
 	DATADIR="$(_get_config 'datadir' "$@")"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [ ! -d "${DATADIR%/}/mysql" ]; then
 		file_env 'MYSQL_ROOT_PASSWORD'
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
 			echo >&2 'error: database is uninitialized and password option is not specified '

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
 	DATADIR="$(_get_config 'datadir' "$@")"
 	mkdir -p "$DATADIR"
-	chown -R mysql:mysql "$DATADIR"
+	chown -R mysql:mysql "$DATADIR" /docker-entrypoint-initdb.d/
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
also `chown -R .../initdb.d` to user mysql while root prior to `gosu exec mysql`