### PR TITLE
Added MYSQL_UID and MYSQL_GID optional arguments / env. variables

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:stretch-slim
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 ARG MYSQL_UID
 ENV MYSQL_UID ${MYSQL_UID:-}
 ARG MYSQL_GID
 ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,7 +1,12 @@
 FROM debian:stretch-slim
 
+ARG MYSQL_UID
+ENV MYSQL_UID ${MYSQL_UID:-}
+ARG MYSQL_GID
+ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:stretch-slim
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 ARG MYSQL_UID
 ENV MYSQL_UID ${MYSQL_UID:-}
 ARG MYSQL_GID
 ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,7 +1,12 @@
 FROM debian:stretch-slim
 
+ARG MYSQL_UID
+ENV MYSQL_UID ${MYSQL_UID:-}
+ARG MYSQL_GID
+ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:stretch-slim
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 ARG MYSQL_UID
 ENV MYSQL_UID ${MYSQL_UID:-}
 ARG MYSQL_GID
 ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -1,7 +1,12 @@
 FROM debian:stretch-slim
 
+ARG MYSQL_UID
+ENV MYSQL_UID ${MYSQL_UID:-}
+ARG MYSQL_GID
+ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,11 +1,10 @@
 FROM debian:stretch-slim
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 ARG MYSQL_UID
 ENV MYSQL_UID ${MYSQL_UID:-}
 ARG MYSQL_GID
 ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,7 +1,12 @@
 FROM debian:stretch-slim
 
+ARG MYSQL_UID
+ENV MYSQL_UID ${MYSQL_UID:-}
+ARG MYSQL_GID
+ENV MYSQL_GID ${MYSQL_GID:-$MYSQL_UID}
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+RUN groupadd -r ${MYSQL_GID:+-g $MYSQL_GID} mysql && useradd -r ${MYSQL_UID:+-u $MYSQL_UID} -g mysql mysql
 
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Passing uid and gid to “docker build” allows for consistent mysql user / group across host and image. 

Also some hosts might have different (compared to debian) ideas about what uid / gid ranges are reserved for system users.

Hope this helps :-)