### PR TITLE
Trigger copy_up operation to happen

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -191,6 +191,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			process_init_file "$f" "${mysql[@]}"
 		done
 
+		find "$DATADIR" -type f -exec touch {} \;
+
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
 			echo >&2
 			echo >&2 'Sorry, this version of MySQL does not support "PASSWORD EXPIRE" (required for MYSQL_ONETIME_PASSWORD).'

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -191,6 +191,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			process_init_file "$f" "${mysql[@]}"
 		done
 
+		find "$DATADIR" -type f -exec touch {} \;
+
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
 			"${mysql[@]}" <<-EOSQL
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -196,6 +196,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			process_init_file "$f" "${mysql[@]}"
 		done
 
+		find "$DATADIR" -type f -exec touch {} \;
+
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
 			"${mysql[@]}" <<-EOSQL
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -198,6 +198,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			process_init_file "$f" "${mysql[@]}"
 		done
 
+		find "$DATADIR" -type f -exec touch {} \;
+
 		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
 			"${mysql[@]}" <<-EOSQL
 				ALTER USER 'root'@'%' PASSWORD EXPIRE;


### PR DESCRIPTION
We've build a small python script which downloads all schemas and migration files (plain SQL) and executes them while starting up mysqld in the background. Since the "aufs" storage engine got deprecated in docker for mac 18.06 some users couldn't start up the container anymore as it would permanently fail. (Although we have no idea why linux users were unaffected as it's a general problem of overlay2)

See https://github.com/moby/moby/issues/35503 and 
https://github.com/docker/for-linux/issues/72#issuecomment-319904698