### PR TITLE
Touch $DATADIR/docker-entrypoint-complete after loading complete

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -205,6 +205,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	touch "$DATADIR/docker-entrypoint-complete"
 fi
 
 exec "$@"

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -205,6 +205,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	touch "$DATADIR/docker-entrypoint-complete"
 fi
 
 exec "$@"

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -210,6 +210,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	touch "$DATADIR/docker-entrypoint-complete"
 fi
 
 exec "$@"

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -212,6 +212,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		echo 'MySQL init process done. Ready for start up.'
 		echo
 	fi
+	touch "$DATADIR/docker-entrypoint-complete"
 fi
 
 exec "$@"


### PR DESCRIPTION
When the mysql container is autoloading data from
/docker-entrypoint-initdb.d/ it's difficult to know when the load has
completed. This is particularly true in a kubernetes
liveliness/readiness check where we don't know if the container is ready
to serve yet.

After the load has finished we touch a file that we can test for the
presence of before responding the container is ready.