### PR TITLE
Enable Toggling of Random Root Password

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -133,7 +133,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
 		fi
 
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a "$MYSQL_RANDOM_ROOT_PASSWORD" != 'no' ]; then
 			export MYSQL_ROOT_PASSWORD="$(pwgen -1 32)"
 			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -139,7 +139,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
 		fi
 
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a "$MYSQL_RANDOM_ROOT_PASSWORD" != 'no' ]; then
 			export MYSQL_ROOT_PASSWORD="$(pwgen -1 32)"
 			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -141,7 +141,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
 		fi
 
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a "$MYSQL_RANDOM_ROOT_PASSWORD" != 'no' ]; then
 			export MYSQL_ROOT_PASSWORD="$(pwgen -1 32)"
 			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi


### PR DESCRIPTION
**Enable a random root password to not be generated even when the `MYSQL_RANDOM_ROOT_PASSWORD` environment variable is set by setting it to a value of `no`.**

According to the Docker image documentation, a random root password can be generated:

> ### `MYSQL_RANDOM_ROOT_PASSWORD`
> 
> This is an optional variable. Set to `yes` to generate a random initial password for the root user (using `pwgen`). The generated root password will be printed to stdout (`GENERATED ROOT PASSWORD: .....`).

However a random root password is generated whenever that environment variable is present, regardless of it's value. There may be times when this variable is present but it's not desired to have a root password generated randomly.

# Example Use Case

```yaml
# docker-compose.yaml (Production)
services:
    mysql:
        image: 'mysql:8.0.15'
        environment:
            MYSQL_ALLOW_EMPTY_PASSWORD: 'this value isnt checked'
            MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
```

```yaml
# docker-compose.override.yaml (Development)
services:
    mysql:
        environment:
            MYSQL_RANDOM_ROOT_PASSWORD: 'no'
```