### PR TITLE
Revert to not using daemonize flag for temporary startup of 5.7 server

### DIFF
--- a/.template.Debian/docker-entrypoint.sh
+++ b/.template.Debian/docker-entrypoint.sh
@@ -86,7 +86,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
-	if [ "${MYSQL_MAJOR}" = '5.6' ]; then
+	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -86,7 +86,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
-	if [ "${MYSQL_MAJOR}" = '5.6' ]; then
+	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -86,7 +86,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
-	if [ "${MYSQL_MAJOR}" = '5.6' ]; then
+	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -86,7 +86,7 @@ mysql_get_config() {
 
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
-	if [ "${MYSQL_MAJOR}" = '5.6' ]; then
+	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i


### PR DESCRIPTION
Daemonize lets us avoid a manual wait loop for the server to be ready, but
for 5.7 it causes a log redirection error when the image is started with -t,
so for now just revert 5.7 image to using the wait loop.