### PR TITLE
Fix config update

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -68,7 +68,7 @@ RUN { \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
 		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
 # don't reverse lookup hostnames, they are usually another container
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+	&& echo -e '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME /var/lib/mysql
 


### PR DESCRIPTION
At least on macOS you have to specify `-e` option for echo, otherwise you won't get line separators.