### PR TITLE
Allow volumeless build

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -68,11 +68,13 @@ RUN { \
 # don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
-VOLUME /var/lib/mysql
-
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]
+
+RUN cp -r /var/lib/mysql /var/lib/mysql-no-volume && chown -R mysql:mysql /var/lib/mysql-no-volume
+
+CMD ["--datadir", "/var/lib/mysql-no-volume"]

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex; \
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 	key='A4A9406876FCBD3C456770C88C718D3B5072E1F5'; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --batch --keyserver pgp.mit.edu --recv-keys "$key"; \
 	gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/mysql.gpg; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 set -eo pipefail
 shopt -s nullglob
 
+find /var/lib/mysql /var/lib/mysql-no-volume -type f -exec touch {} \;
+
 # logging functions
 mysql_log() {
 	local type="$1"; shift


### PR DESCRIPTION
Allow building a mysql 5.6 image without volumes
This allows the image to be used to create a snapshot of
a database for testing. Data will be written to /var/lib/mysql-no-volume
and the image can be committed in its entirety by committing the container