### PR TITLE
strip newline from all passed variables

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -35,6 +35,12 @@ file_env() {
 	elif [ "${!fileVar:-}" ]; then
 		val="$(< "${!fileVar}")"
 	fi
+        # remove newline from values which would cause troubles later if present
+        new_val=$(echo "$val"|tr -d '\n')
+        if [ "$new_val" != "$val" ]; then
+                mysql_warn "Stripping newline from ${var}."
+                val="$new_val"
+        fi
 	export "$var"="$val"
 	unset "$fileVar"
 }

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -35,6 +35,12 @@ file_env() {
 	elif [ "${!fileVar:-}" ]; then
 		val="$(< "${!fileVar}")"
 	fi
+        # remove newline from values which would cause troubles later if present
+        new_val=$(echo "$val"|tr -d '\n')
+        if [ "$new_val" != "$val" ]; then
+                mysql_warn "Stripping newline from ${var}."
+                val="$new_val"
+        fi
 	export "$var"="$val"
 	unset "$fileVar"
 }

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -35,6 +35,12 @@ file_env() {
 	elif [ "${!fileVar:-}" ]; then
 		val="$(< "${!fileVar}")"
 	fi
+        # remove newline from values which would cause troubles later if present
+        new_val=$(echo "$val"|tr -d '\n')
+        if [ "$new_val" != "$val" ]; then
+                mysql_warn "Stripping newline from ${var}."
+                val="$new_val"
+        fi
 	export "$var"="$val"
 	unset "$fileVar"
 }


### PR DESCRIPTION
This prevents weird errors when attributes get shifted to newline and are executed by docker-entrypoint.sh. This PR removes the newline and when newline is stripped a 'Warning' is printed.

Short version: `docker-entrypoint.sh` scripts breaks (as seen later in examples of this PR) when 'newline' is present with rather ugly error that is hard to analyze without checking the code of script.
Better error message or automated removal of 'newline' would be more desirable. This PR proposes automated 'newline' removal.

Long version:
I have run into this when trying to get image working with kubernetes and erroneously generated 'kubernetes secret' that contained the newline at the end. From looking at the logs the error that I have made required me to do debugging of image as there was no good message on what is going on. I believe there is no practical use case for having 'newline' in any of variables (if this is not true please correct me). 

After the change proposed here the mysql image would progress with only printing warning when 'newline' is included which would make this work in most cases. With kubernetes the newline is preserved at the end of string which makes this invisible to user if such mistake is done. 
Alternative approach to this would be to "hard fail" with error that 'newline' was encountered in some variable as that will most probably never be desired and user should be aware of it. 

Main idea for creating this PR is to avoid unnecessary image debugging when 'newline' is accidentally included in any of the variables. 

Please let me know what you think about this change and also let me know there are any changes needed for this to be merged. Thank you!

How to reproduce issue:
~~~
# a="aa
bb"
# docker run --name t56 -e MYSQL_ROOT_PASSWORD="$a" -d mysql:5.6 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
xxxxxxxx
# docker logs -f xxxxxxxx
~~~

**mysql:5.6**
~~~
...
2019-12-08 08:18:54+00:00 [Note] [Entrypoint]: Temporary server started.
Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
2019-12-08 08:18:56 96 [Warning] 'proxies_priv' entry '@ root@0b2ef1dce921' ignored in --skip-name-resolve mode.

2019-12-08 08:18:56+00:00 [Note] [Entrypoint]: Stopping temporary server
mysqladmin: unknown option '--bb"'
2019-12-08 08:18:56+00:00 [ERROR] [Entrypoint]: Unable to shut down server.
~~~

**mysql:5.7**
~~~
...
2019-12-08 08:20:09+00:00 [Note] [Entrypoint]: Temporary server started.
Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.

2019-12-08 08:20:17+00:00 [Note] [Entrypoint]: Stopping temporary server
mysqladmin: [ERROR] unknown option '--bb"'
2019-12-08 08:20:17+00:00 [ERROR] [Entrypoint]: Unable to shut down server.
~~~

**mysql:8.0**
~~~
...
2019-12-08 08:22:48+00:00 [Note] [Entrypoint]: Temporary server started.
2019-12-08T08:22:48.929209Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: '/var/run/mysqld/mysqlx.sock'
Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.

2019-12-08 08:22:54+00:00 [Note] [Entrypoint]: Stopping temporary server
mysqladmin: [ERROR] unknown option '--bb"'.
2019-12-08 08:22:54+00:00 [ERROR] [Entrypoint]: Unable to shut down server.
~~~

After fix the mysql can start properly and following can be seen in logs if there was any newline stripped (including the name of variable from which it was stripped so user can fix it):
~~~
2019-12-08 08:38:22+00:00 [Warn] [Entrypoint]: Stripping newline from MYSQL_ROOT_PASSWORD.
~~~