### PR TITLE
Dump on container termination

### DIFF
--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 shopt -s nullglob
-
+trap "/usr/bin/mysqldump -u root --password=root $MYSQL_DATABASE > /docker-entrypoint-initdb.d/dump.sql" SIGTERM
 # logging functions
 mysql_log() {
 	local type="$1"; shift


### PR DESCRIPTION
I think there is a problem with saving db after container stopped.
I have no possibility to change that behaviour with docker-compose in the new dockerfile
So i suggest to add some trap signals to save db data before container stops