### PR TITLE
Removed deprecated options for symbolic links.

### DIFF
--- a/8.0/config/my.cnf
+++ b/8.0/config/my.cnf
@@ -24,8 +24,6 @@ pid-file        = /var/run/mysqld/mysqld.pid
 socket          = /var/run/mysqld/mysqld.sock
 datadir         = /var/lib/mysql
 secure-file-priv= NULL
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
 
 # Custom config should go here
 !includedir /etc/mysql/conf.d/


### PR DESCRIPTION
## Overview
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-2.html
`symbolic-links=0` is deprecated in 8.0.2 and later versions. 
This option will be removed in the future.

https://dev.mysql.com/doc/refman/8.0/en/symbolic-links-to-tables.html
We don't need to specify this option, as it is also disabled by default.
As long as this setting is specified, unnecessary warnings occur when the container is launched, so I removed it.

## Expected Logs
↓Exist `symbolic-links=0`
```
2020-05-26 00:45:26+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.20-1debian10 started.
2020-05-26 00:45:26+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2020-05-26 00:45:26+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.20-1debian10 started.
2020-05-26 00:45:26+00:00 [Note] [Entrypoint]: Initializing database files
2020-05-26T00:45:26.849271Z 0 [Warning] [MY-011070] [Server] 'Disabling symbolic links using --skip-symbolic-links (or equivalent) is the default. Consider not using this option as it' is deprecated and will be removed in a future release.
2020-05-26T00:45:26.849849Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.20) initializing of server in progress as process 45
```

↓ Remove `symbolic-links=0`
```
2020-05-26 00:38:38+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.20-1debian10 started.
2020-05-26 00:38:38+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2020-05-26 00:38:38+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.20-1debian10 started.
2020-05-26 00:38:38+00:00 [Note] [Entrypoint]: Initializing database files
2020-05-26T00:38:38.794793Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.20) initializing of server in progress as process 44
```

It is expected that the warning on line 5 will **not** be output.