### PR TITLE
Add Oracle Linux image variants

### DIFF
--- a/5.7/Dockerfile.oracle
+++ b/5.7/Dockerfile.oracle
@@ -1,0 +1,108 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM oraclelinux:7-slim
+
+RUN set -eux; \
+	groupadd --system --gid 999 mysql; \
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
+	\
+	mkdir /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d
+
+# add gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.12
+RUN set -eux; \
+# TODO find a better userspace architecture detection method than querying the kernel
+	arch="$(uname -m)"; \
+	case "$arch" in \
+		aarch64) gosuArch='arm64' ;; \
+		x86_64) gosuArch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	curl -fL -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch.asc"; \
+	curl -fL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN set -eux; \
+# https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+# gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+	key='859BE8D7C586F538430B19C2467B942D3A79BD29'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	gpg --batch --export --armor "$key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql; \
+	rm -rf "$GNUPGHOME"
+
+ENV MYSQL_MAJOR 5.7
+ENV MYSQL_VERSION 5.7.37-1.el7
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql5.7-server-minimal]'; \
+		echo 'name=MySQL 5.7 Server Minimal'; \
+		echo 'enabled=1'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-5.7-community/docker/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-minimal.repo
+
+RUN set -eux; \
+	yum install -y "mysql-community-server-minimal-$MYSQL_VERSION"; \
+	yum clean all; \
+# the "socket" value in the Oracle packages is set to "/var/lib/mysql" which isn't a great place for the socket (we want it in "/var/run/mysqld" instead)
+# https://github.com/docker-library/mysql/pull/680#issuecomment-636121520
+	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
+	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
+	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	\
+# make sure users dumping files in "/etc/mysql/conf.d" still works
+	! grep -F '!includedir' /etc/my.cnf; \
+	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/conf.d; \
+	\
+	mysqld --version; \
+	mysql --version
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql-tools-community]'; \
+		echo 'name=MySQL Tools Community'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-tools-community/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'enabled=1'; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-tools.repo
+ENV MYSQL_SHELL_VERSION 8.0.28-1.el7
+RUN set -eux; \
+	yum install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
+	yum clean all; \
+	\
+	mysqlsh --version
+
+VOLUME /var/lib/mysql
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3306 33060
+CMD ["mysqld"]

--- a/8.0/Dockerfile.oracle
+++ b/8.0/Dockerfile.oracle
@@ -1,0 +1,111 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM oraclelinux:8-slim
+
+RUN set -eux; \
+	groupadd --system --gid 999 mysql; \
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
+	\
+	mkdir /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d
+
+# add gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.12
+RUN set -eux; \
+# TODO find a better userspace architecture detection method than querying the kernel
+	arch="$(uname -m)"; \
+	case "$arch" in \
+		aarch64) gosuArch='arm64' ;; \
+		x86_64) gosuArch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	curl -fL -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch.asc"; \
+	curl -fL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN set -eux; \
+# https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+# gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+	key='859BE8D7C586F538430B19C2467B942D3A79BD29'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	gpg --batch --export --armor "$key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql; \
+	rm -rf "$GNUPGHOME"
+
+# Oracle Linux 8+ is very slim :)
+RUN set -eux; microdnf install -y findutils; microdnf clean all
+
+ENV MYSQL_MAJOR 8.0
+ENV MYSQL_VERSION 8.0.28-1.el8
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql8.0-server-minimal]'; \
+		echo 'name=MySQL 8.0 Server Minimal'; \
+		echo 'enabled=1'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-8.0-community/docker/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-minimal.repo
+
+RUN set -eux; \
+	microdnf install -y "mysql-community-server-minimal-$MYSQL_VERSION"; \
+	microdnf clean all; \
+# the "socket" value in the Oracle packages is set to "/var/lib/mysql" which isn't a great place for the socket (we want it in "/var/run/mysqld" instead)
+# https://github.com/docker-library/mysql/pull/680#issuecomment-636121520
+	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
+	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
+	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	\
+# make sure users dumping files in "/etc/mysql/conf.d" still works
+	! grep -F '!includedir' /etc/my.cnf; \
+	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/conf.d; \
+	\
+	mysqld --version; \
+	mysql --version
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql-tools-community]'; \
+		echo 'name=MySQL Tools Community'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-tools-community/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'enabled=1'; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-tools.repo
+ENV MYSQL_SHELL_VERSION 8.0.28-1.el8
+RUN set -eux; \
+	microdnf install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
+	microdnf clean all; \
+	\
+	mysqlsh --version
+
+VOLUME /var/lib/mysql
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3306 33060
+CMD ["mysqld"]

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -31,15 +31,18 @@ generated_warning() {
 for version; do
 	export version
 
-	debianVersion="$(jq -r '.[env.version].debian // ""' versions.json)"
-	if [ -n "$debianVersion" ]; then
-		dockerfile='Dockerfile.debian'
+	for variant in oracle debian; do
+		export variant
 
-		{
-			generated_warning
-			gawk -f "$jqt" "template/$dockerfile"
-		} > "$version/$dockerfile"
-	fi
+		variantVersion="$(jq -r '.[env.version][env.variant] // {} | .version // ""' versions.json)"
+		if [ -n "$variantVersion" ]; then
+			dockerfile="Dockerfile.$variant"
+			{
+				generated_warning
+				gawk -f "$jqt" "template/$dockerfile"
+			} > "$version/$dockerfile"
+		fi
+	done
 
 	cp -a template/docker-entrypoint.sh "$version/docker-entrypoint.sh"
 done

--- a/template/Dockerfile.oracle
+++ b/template/Dockerfile.oracle
@@ -1,0 +1,108 @@
+{{ def dnf: if .oracle.variant | startswith("7") then "yum" else "microdnf" end -}}
+FROM oraclelinux:{{ .oracle.variant }}
+
+RUN set -eux; \
+	groupadd --system --gid 999 mysql; \
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
+	\
+	mkdir /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d
+
+# add gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.12
+RUN set -eux; \
+# TODO find a better userspace architecture detection method than querying the kernel
+	arch="$(uname -m)"; \
+	case "$arch" in \
+		aarch64) gosuArch='arm64' ;; \
+		x86_64) gosuArch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	curl -fL -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch.asc"; \
+	curl -fL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN set -eux; \
+# https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+# gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+	key='859BE8D7C586F538430B19C2467B942D3A79BD29'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	gpg --batch --export --armor "$key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql; \
+	rm -rf "$GNUPGHOME"
+
+{{ if .oracle.variant | startswith("7") then "" else ( -}}
+# Oracle Linux 8+ is very slim :)
+RUN set -eux; {{ dnf }} install -y findutils; {{ dnf }} clean all
+
+{{ ) end -}}
+ENV MYSQL_MAJOR {{ env.version }}
+ENV MYSQL_VERSION {{ .oracle.version }}
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql{{ env.version }}-server-minimal]'; \
+		echo 'name=MySQL {{ env.version }} Server Minimal'; \
+		echo 'enabled=1'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-{{ env.version }}-community/docker/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-minimal.repo
+
+RUN set -eux; \
+	{{ dnf }} install -y "mysql-community-server-minimal-$MYSQL_VERSION"; \
+	{{ dnf }} clean all; \
+# the "socket" value in the Oracle packages is set to "/var/lib/mysql" which isn't a great place for the socket (we want it in "/var/run/mysqld" instead)
+# https://github.com/docker-library/mysql/pull/680#issuecomment-636121520
+	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
+	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
+	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	\
+# make sure users dumping files in "/etc/mysql/conf.d" still works
+	! grep -F '!includedir' /etc/my.cnf; \
+	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/conf.d; \
+	\
+	mysqld --version; \
+	mysql --version
+
+RUN set -eu; \
+	. /etc/os-release; \
+	{ \
+		echo '[mysql-tools-community]'; \
+		echo 'name=MySQL Tools Community'; \
+		echo "baseurl=https://repo.mysql.com/yum/mysql-tools-community/el/${VERSION_ID%%[.-]*}/\$basearch/"; \
+		echo 'enabled=1'; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-tools.repo
+ENV MYSQL_SHELL_VERSION {{ .["mysql-shell"].version }}
+RUN set -eux; \
+	{{ dnf }} install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
+	{{ dnf }} clean all; \
+	\
+	mysqlsh --version
+
+VOLUME /var/lib/mysql
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3306 33060
+CMD ["mysqld"]

--- a/versions.json
+++ b/versions.json
@@ -7,6 +7,16 @@
       "suite": "buster",
       "version": "5.7.37-1debian10"
     },
+    "mysql-shell": {
+      "version": "8.0.28-1.el7"
+    },
+    "oracle": {
+      "architectures": [
+        "amd64"
+      ],
+      "variant": "7-slim",
+      "version": "5.7.37-1.el7"
+    },
     "version": "5.7.37"
   },
   "8.0": {
@@ -16,6 +26,17 @@
       ],
       "suite": "buster",
       "version": "8.0.28-1debian10"
+    },
+    "mysql-shell": {
+      "version": "8.0.28-1.el8"
+    },
+    "oracle": {
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ],
+      "variant": "8-slim",
+      "version": "8.0.28-1.el8"
     },
     "version": "8.0.28"
   }

--- a/versions.sh
+++ b/versions.sh
@@ -3,8 +3,31 @@ set -Eeuo pipefail
 
 defaultDebianSuite='buster'
 declare -A debianSuites=(
-	#[5.6]='stretch'
+	#[8.0]='stretch'
 )
+
+defaultOracleVariant='8-slim'
+declare -A oracleVariants=(
+	[5.7]='7-slim'
+)
+
+# https://repo.mysql.com/yum/mysql-8.0-community/docker/
+declare -A bashbrewArchToRpmArch=(
+	[amd64]='x86_64'
+	[arm64v8]='aarch64'
+)
+
+fetch_rpm_versions() {
+	local repo="$1"; shift
+	local arch="$1"; shift
+	local oracleVersion="$1"; shift
+	local package="$1"; shift
+
+	curl -fsSL "$repo/$arch/" 2>/dev/null \
+		| grep -oE '"'"$package"'-[0-9][^"]+[.]el'"$oracleVersion"'[.]'"$arch"'[.]rpm"' \
+		| sed -r 's/^"'"$package-|[.]$arch[.]rpm"'"$//g' \
+		| sort -rV
+}
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
@@ -20,36 +43,99 @@ versions=( "${versions[@]%/}" )
 for version in "${versions[@]}"; do
 	export version
 
-	debianSuite="${debianSuites[$version]:-$defaultDebianSuite}"
-	debianVersion="$(
-		curl -fsSL "https://repo.mysql.com/apt/debian/dists/$debianSuite/mysql-$version/binary-amd64/Packages.gz" \
-			| gunzip \
-			| awk -F ': ' '
-				$1 == "Package" {
-					pkg = $2
-					next
-				}
-				pkg == "mysql-server" && $1 == "Version" {
-					print $2
+	doc='{}'
+
+	if [[ "$version" == 5.* ]] || [ "$version" = '8.0' ]; then
+		debianSuite="${debianSuites[$version]:-$defaultDebianSuite}"
+		debianVersion="$(
+			curl -fsSL "https://repo.mysql.com/apt/debian/dists/$debianSuite/mysql-$version/binary-amd64/Packages.gz" \
+				| gunzip \
+				| awk -F ': ' '
+					$1 == "Package" {
+						pkg = $2
+						next
+					}
+					pkg == "mysql-server" && $1 == "Version" {
+						print $2
+					}
+				'
+		)"
+
+		# example 8.0.22-1debian10 => 8.0.22
+		baseVersion="${debianVersion%-*}"
+
+		export baseVersion debianSuite debianVersion
+		doc="$(
+			jq <<<"$doc" -c '
+				. += {
+					version: env.baseVersion,
+					debian: {
+						architectures: [ "amd64" ],
+						suite: env.debianSuite,
+						version: env.debianVersion,
+					},
 				}
 			'
-	)"
+		)"
+	fi
 
-	# example 8.0.22-1debian10 => 8.0.22
-	baseVersion="${debianVersion%-*}"
+	oracleVariant="${oracleVariants[$version]:-$defaultOracleVariant}"
+	oracleVersion="${oracleVariant%%-*}" # "7", etc
+	rpmVersion=
+	shellVersion=
+	doc="$(jq <<<"$doc" -c '. += { oracle: { architectures: [] } }')"
+	for bashbrewArch in $(xargs -n1 <<<"${!bashbrewArchToRpmArch[*]}" | sort | xargs); do
+		rpmArch="${bashbrewArchToRpmArch[$bashbrewArch]}"
+		rpmRepo="https://repo.mysql.com/yum/mysql-$version-community/docker/el/$oracleVersion"
+		archVersions="$(
+			fetch_rpm_versions "$rpmRepo" "$rpmArch" "$oracleVersion" 'mysql-community-server-minimal' \
+				| grep -E "^$version[.]" \
+				|| :
+		)"
+		archVersion="$(head -1 <<<"$archVersions")"
+		[ -n "$archVersion" ] || continue
+		if [ -z "$rpmVersion" ]; then
+			rpmVersion="$archVersion"
+		elif [ "$rpmVersion" != "$archVersion" ]; then
+			echo >&2 "error: $version architecture version mismatch! ('$rpmVersion' vs '$archVersion' on '$rpmArch'/'$bashbrewArch')"
+			exit 1
+		fi
+		shellArchVersions="$(fetch_rpm_versions "https://repo.mysql.com/yum/mysql-tools-community/el/$oracleVersion" "$rpmArch" "$oracleVersion" 'mysql-shell')"
+		shellArchVersion="$(head -1 <<<"$shellArchVersions")"
+		if [ -z "$shellVersion" ]; then
+			shellVersion="$shellArchVersion"
+		elif [ "$shellVersion" != "$shellArchVersion" ]; then
+			echo >&2 "error: shell version mismatch! ('$shellVersion' vs '$shellArchVersion' on '$rpmArch'/'$bashbrewArch')"
+			exit 1
+		fi
+		export bashbrewArch
+		doc="$(jq <<<"$doc" -c '.oracle.architectures = (.oracle.architectures + [ env.bashbrewArch ] | sort)')"
+	done
+	baseVersion="$(jq <<<"$doc" -r '.version // ""')"
+	# example 8.0.22-1.el7 => 8.0.22
+	oracleBaseVersion="${rpmVersion%-*}"
+	: "${baseVersion:=$oracleBaseVersion}"
+	if [ "$baseVersion" != "$oracleBaseVersion" ]; then
+		echo >&2 "error: Oracle and Debian version mismatch! ('$oracleBaseVersion' vs '$baseVersion')"
+		exit 1
+	fi
+	export baseVersion rpmVersion shellVersion oracleVariant
+	doc="$(jq <<<"$doc" -c '
+		. += {
+			version: env.baseVersion,
+			oracle: (.oracle + {
+				version: env.rpmVersion,
+				variant: env.oracleVariant,
+			}),
+			"mysql-shell": {
+				version: env.shellVersion,
+			},
+		}
+	')"
 
-	export baseVersion debianSuite debianVersion
-	json="$(
-		jq <<<"$json" -c \
-			'.[env.version] = {
-				version: env.baseVersion,
-				debian: {
-					architectures: [ "amd64" ],
-					suite: env.debianSuite,
-					version: env.debianVersion,
-				},
-			}'
-	)"
+	echo "$version: $baseVersion"
+
+	json="$(jq <<<"$json" -c --argjson doc "$doc" '.[env.version] = $doc')"
 done
 
 jq <<<"$json" -S . > versions.json


### PR DESCRIPTION
The primary benefits of this are arm64 support (in 8.0) and smaller images (in 5.7 and 8.0).

```console
$ docker images mysql --format 'table {{ .Tag }}\t{{ .Size }}' | sort -rV
TAG          SIZE
8.0-oracle   404MB
8.0          556MB
5.7-oracle   371MB
5.7          447MB
5.6-oracle   386MB
5.6          303MB
```

Closes #390
Closes #318
Closes #289
Closes #822

This is a fusion of what @ltangvald started in https://github.com/docker-library/mysql/issues/289#issuecomment-547328690, the existing Debian variants, and what's in https://github.com/mysql/mysql-docker (in a very similar way to the layout @yosifkit described/suggested in https://github.com/docker-library/mysql/issues/289#issuecomment-548153826).