### PR TITLE
Make arbitrary user work better out-of-the-box

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -70,7 +70,7 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	&& chmod 1777 /var/run/mysqld /var/lib/mysql \
 # comment out a few problematic configuration values
 	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -72,7 +72,7 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	&& chmod 1777 /var/run/mysqld /var/lib/mysql \
 # comment out a few problematic configuration values
 	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -72,7 +72,7 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
+	&& chmod 1777 /var/run/mysqld /var/lib/mysql
 
 VOLUME /var/lib/mysql
 # Config files


### PR DESCRIPTION
Fixes https://github.com/docker-library/mysql/issues/709

Also tightens permissions for the run dir to ensure other users can't delete the socket and pid file.