### PR TITLE
Override time-zone option when initializing database

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -98,7 +98,7 @@ mysql_get_config() {
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
 	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i
 		for i in {30..0}; do
@@ -118,7 +118,7 @@ docker_temp_server_start() {
 		fi
 	else
 		# For 5.7+ the server is ready for use as soon as startup command unblocks
-		if ! "$@" --daemonize --skip-networking --socket="${SOCKET}"; then
+		if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
 			mysql_error "Unable to start server."
 		fi
 	fi
@@ -158,9 +158,9 @@ docker_create_db_directories() {
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
 	if [ "$MYSQL_MAJOR" = '5.6' ]; then
-		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}"
+		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}" --default-time-zone=SYSTEM
 	else
-		"$@" --initialize-insecure
+		"$@" --initialize-insecure --default-time-zone=SYSTEM
 	fi
 	mysql_note "Database files initialized"
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -98,7 +98,7 @@ mysql_get_config() {
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
 	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i
 		for i in {30..0}; do
@@ -118,7 +118,7 @@ docker_temp_server_start() {
 		fi
 	else
 		# For 5.7+ the server is ready for use as soon as startup command unblocks
-		if ! "$@" --daemonize --skip-networking --socket="${SOCKET}"; then
+		if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
 			mysql_error "Unable to start server."
 		fi
 	fi
@@ -158,9 +158,9 @@ docker_create_db_directories() {
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
 	if [ "$MYSQL_MAJOR" = '5.6' ]; then
-		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}"
+		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}" --default-time-zone=SYSTEM
 	else
-		"$@" --initialize-insecure
+		"$@" --initialize-insecure --default-time-zone=SYSTEM
 	fi
 	mysql_note "Database files initialized"
 

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -98,7 +98,7 @@ mysql_get_config() {
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
 	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i
 		for i in {30..0}; do
@@ -118,7 +118,7 @@ docker_temp_server_start() {
 		fi
 	else
 		# For 5.7+ the server is ready for use as soon as startup command unblocks
-		if ! "$@" --daemonize --skip-networking --socket="${SOCKET}"; then
+		if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
 			mysql_error "Unable to start server."
 		fi
 	fi
@@ -158,9 +158,9 @@ docker_create_db_directories() {
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
 	if [ "$MYSQL_MAJOR" = '5.6' ]; then
-		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}"
+		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}" --default-time-zone=SYSTEM
 	else
-		"$@" --initialize-insecure
+		"$@" --initialize-insecure --default-time-zone=SYSTEM
 	fi
 	mysql_note "Database files initialized"
 

--- a/template/docker-entrypoint.sh
+++ b/template/docker-entrypoint.sh
@@ -98,7 +98,7 @@ mysql_get_config() {
 # Do a temporary startup of the MySQL server, for init purposes
 docker_temp_server_start() {
 	if [ "${MYSQL_MAJOR}" = '5.6' ] || [ "${MYSQL_MAJOR}" = '5.7' ]; then
-		"$@" --skip-networking --socket="${SOCKET}" &
+		"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" &
 		mysql_note "Waiting for server startup"
 		local i
 		for i in {30..0}; do
@@ -118,7 +118,7 @@ docker_temp_server_start() {
 		fi
 	else
 		# For 5.7+ the server is ready for use as soon as startup command unblocks
-		if ! "$@" --daemonize --skip-networking --socket="${SOCKET}"; then
+		if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
 			mysql_error "Unable to start server."
 		fi
 	fi
@@ -158,9 +158,9 @@ docker_create_db_directories() {
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
 	if [ "$MYSQL_MAJOR" = '5.6' ]; then
-		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}"
+		mysql_install_db --datadir="$DATADIR" --rpm --keep-my-cnf "${@:2}" --default-time-zone=SYSTEM
 	else
-		"$@" --initialize-insecure
+		"$@" --initialize-insecure --default-time-zone=SYSTEM
 	fi
 	mysql_note "Database files initialized"
 


### PR DESCRIPTION
Initializing a database with a config that specifies `default-time-zone` ends up with an error:

> Fatal error: Illegal or unknown default time zone 'Europe/Tallinn'

This adds a workaround to the problem to force the system timezone (similarly to `--initialize-insecure`, `--skip-networking` options used in init db process), so the database can be initialized, and timezones be imported after database init.

Implements solution described at:
- https://github.com/docker-library/mysql/issues/543#issuecomment-775895366

Why this is brought up again? It's because a config file offers a unified way to configure MySQL instance, compared to setting up environment variables for different systems (docker run, docker-compose, kubernetes, ...).

---- 

Local build commands:
```
git clone --depth 1 -b patch-1 https://github.com/glensc/docker-library-mysql mysql-pr739 && cd mysql-pr739
docker build 5.6 -t mysql:5.6_pr739 -f 5.6/Dockerfile.debian
docker build 5.7 -t mysql:5.7_pr739 -f 5.7/Dockerfile.debian
docker build 8.0 -t mysql:8.0_pr739 -f 8.0/Dockerfile.debian
```

Local test commands:

```
docker run --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:5.6_pr739 gosu mysql bash -x /entrypoint.sh mysqld --default-time-zone=Europe/Tallinn
docker run --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:5.7_pr739 gosu mysql bash -x /entrypoint.sh mysqld --default-time-zone=Europe/Tallinn
docker run --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=1 mysql:8.0_pr739 gosu mysql bash -x /entrypoint.sh mysqld --default-time-zone=Europe/Tallinn
```