### PR TITLE
Correct the error condition introduced by #749

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -154,7 +154,7 @@ docker_verify_minimum_env() {
 	fi
 
 	# This will prevent the CREATE USER from failing (and thus exiting with a half-initialized database)
-	if [ "$MYSQL_USER" = 'root' ]; then
+	if [ "$MYSQL_USER" = 'root' ] && [ -n "$MYSQL_PASSWORD" ]; then
 		mysql_error <<-'EOF'
 			MYSQL_USER="root", MYSQL_PASSWORD cannot be used for the root user
 			    Use one of the following to control the root user password:

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -154,7 +154,7 @@ docker_verify_minimum_env() {
 	fi
 
 	# This will prevent the CREATE USER from failing (and thus exiting with a half-initialized database)
-	if [ "$MYSQL_USER" = 'root' ]; then
+	if [ "$MYSQL_USER" = 'root' ] && [ -n "$MYSQL_PASSWORD" ]; then
 		mysql_error <<-'EOF'
 			MYSQL_USER="root", MYSQL_PASSWORD cannot be used for the root user
 			    Use one of the following to control the root user password:

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -154,7 +154,7 @@ docker_verify_minimum_env() {
 	fi
 
 	# This will prevent the CREATE USER from failing (and thus exiting with a half-initialized database)
-	if [ "$MYSQL_USER" = 'root' ]; then
+	if [ "$MYSQL_USER" = 'root' ] && [ -n "$MYSQL_PASSWORD" ]; then
 		mysql_error <<-'EOF'
 			MYSQL_USER="root", MYSQL_PASSWORD cannot be used for the root user
 			    Use one of the following to control the root user password:

--- a/template/docker-entrypoint.sh
+++ b/template/docker-entrypoint.sh
@@ -154,7 +154,7 @@ docker_verify_minimum_env() {
 	fi
 
 	# This will prevent the CREATE USER from failing (and thus exiting with a half-initialized database)
-	if [ "$MYSQL_USER" = 'root' ]; then
+	if [ "$MYSQL_USER" = 'root' ] && [ -n "$MYSQL_PASSWORD" ]; then
 		mysql_error <<-'EOF'
 			MYSQL_USER="root", MYSQL_PASSWORD cannot be used for the root user
 			    Use one of the following to control the root user password:


### PR DESCRIPTION
This PR corrects the error condition introduced by #749.
The condition is wrong so that a root user can't create a new database even when the password is given by `MYSQL_ROOT_PASSWORD` (cf. #750).