### PR TITLE
Fixed permissions on /var/run/mysqld.

### DIFF
--- a/8.0/Dockerfile.debian
+++ b/8.0/Dockerfile.debian
@@ -82,7 +82,8 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 1777 /var/run/mysqld /var/lib/mysql
+	&& chmod 1775 /var/run/mysqld \
+	&& chmod 1777 /var/lib/mysql
 
 VOLUME /var/lib/mysql
 


### PR DESCRIPTION
Fixes for the following warnings.
```
2021-04-03T01:01:06.188231+09:00 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
```
