### PR TITLE
Add .sql.zst support to docker-entrypoint-initdb.d

### DIFF
--- a/5.7/Dockerfile.debian
+++ b/5.7/Dockerfile.debian
@@ -46,8 +46,8 @@ RUN set -eux; \
 # Sys::Hostname
 # Data::Dumper
 		perl \
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
 		xz-utils \
+		zstd \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/5.7/Dockerfile.oracle
+++ b/5.7/Dockerfile.oracle
@@ -43,6 +43,7 @@ RUN set -eux; \
 		gzip \
 		openssl \
 		xz \
+		zstd \
 	; \
 	yum clean all
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -72,10 +72,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/8.0/Dockerfile.debian
+++ b/8.0/Dockerfile.debian
@@ -46,8 +46,8 @@ RUN set -eux; \
 # Sys::Hostname
 # Data::Dumper
 		perl \
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
 		xz-utils \
+		zstd \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/8.0/Dockerfile.oracle
+++ b/8.0/Dockerfile.oracle
@@ -43,6 +43,7 @@ RUN set -eux; \
 		gzip \
 		openssl \
 		xz \
+		zstd \
 # Oracle Linux 8+ is very slim :)
 		findutils \
 	; \

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -72,10 +72,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done

--- a/template/Dockerfile.debian
+++ b/template/Dockerfile.debian
@@ -40,8 +40,8 @@ RUN set -eux; \
 # Sys::Hostname
 # Data::Dumper
 		perl \
-# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
 		xz-utils \
+		zstd \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/template/Dockerfile.oracle
+++ b/template/Dockerfile.oracle
@@ -38,6 +38,7 @@ RUN set -eux; \
 		gzip \
 		openssl \
 		xz \
+		zstd \
 {{ if .oracle.variant | startswith("7") then "" else ( -}}
 # Oracle Linux 8+ is very slim :)
 		findutils \

--- a/template/docker-entrypoint.sh
+++ b/template/docker-entrypoint.sh
@@ -72,10 +72,11 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
 	done


### PR DESCRIPTION
Zstandard outperforms gzip and xz in many metrics, it would be beneficial to support it.

Mirroring additions done in MariaDB (MariaDB/mariadb-docker#376) and PostgreSQL (docker-library/postgres#846).