### PR TITLE
Treat an existing but empty /var/lib/mysql as nonexistent database

### DIFF
--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -220,8 +220,10 @@ docker_setup_env() {
 	file_env 'MYSQL_PASSWORD'
 	file_env 'MYSQL_ROOT_PASSWORD'
 
+    # If the directory exists but is empty (e.d. it's a volume mount),
+    # assume the database to be uninitialized.
 	declare -g DATABASE_ALREADY_EXISTS
-	if [ -d "$DATADIR/mysql" ]; then
+	if [ -d "$DATADIR/mysql" -a -z "$(ls -A1 "$DATADIR/mysql")" ]; then
 		DATABASE_ALREADY_EXISTS='true'
 	fi
 }


### PR DESCRIPTION
I'm trying to setup mysql in a local minikube environment and I want the storage to be persistent across pod restarts. So I have to mount `/var/lib/mysql`, but then mysql refuses to execute scripts in `/docker-entrypoint-initdb.d`. So I added a second check to make sure that the data directory is not only existing but also nonempty.

I can make a workaround (like, log into the container and run the scripts!) but I would prefer to have a generic solution.

See also https://stackoverflow.com/questions/38504257 