### PR TITLE
update GOSU to 1.14

### DIFF
--- a/5.6/Dockerfile.debian
+++ b/5.6/Dockerfile.debian
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr &
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/5.7/Dockerfile.debian
+++ b/5.7/Dockerfile.debian
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr &
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/8.0/Dockerfile.debian
+++ b/8.0/Dockerfile.debian
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr &
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/template/Dockerfile.debian
+++ b/template/Dockerfile.debian
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gnupg dirmngr &
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \


### PR DESCRIPTION
Signed-off-by: daniel sutton <daniel@ducksecops.uk>

Upgradet GOSU 1.14 from prevous GOSU 1.12. Newer version is based on GO 1.16.7 which is supported.