### PR TITLE
refactor: recurse docker-entrypoint-initdb.d dir files

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -393,7 +393,7 @@ _main() {
 			mysql_note "Temporary server started."
 
 			docker_setup_db
-			docker_process_init_files /docker-entrypoint-initdb.d/*
+			docker_process_init_files $(find /docker-entrypoint-initdb.d/  -type f | sort )
 
 			mysql_expire_root_user
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -393,7 +393,7 @@ _main() {
 			mysql_note "Temporary server started."
 
 			docker_setup_db
-			docker_process_init_files /docker-entrypoint-initdb.d/*
+			docker_process_init_files $(find /docker-entrypoint-initdb.d/  -type f | sort )
 
 			mysql_expire_root_user
 

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -393,7 +393,7 @@ _main() {
 			mysql_note "Temporary server started."
 
 			docker_setup_db
-			docker_process_init_files /docker-entrypoint-initdb.d/*
+			docker_process_init_files $(find /docker-entrypoint-initdb.d/  -type f | sort )
 
 			mysql_expire_root_user
 


### PR DESCRIPTION
can use docker-entrypoint-initdb.d recurse dir files to import 