### PR TITLE
Update socket location for mysql clients

### DIFF
--- a/5.7/Dockerfile.oracle
+++ b/5.7/Dockerfile.oracle
@@ -78,6 +78,7 @@ RUN set -eux; \
 	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
 	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
 	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	{ echo '[client]'; echo 'socket=/var/run/mysqld/mysqld.sock'; } >> /etc/my.cnf; \
 	\
 # make sure users dumping files in "/etc/mysql/conf.d" still works
 	! grep -F '!includedir' /etc/my.cnf; \

--- a/8.0/Dockerfile.oracle
+++ b/8.0/Dockerfile.oracle
@@ -80,6 +80,7 @@ RUN set -eux; \
 	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
 	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
 	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	{ echo '[client]'; echo 'socket=/var/run/mysqld/mysqld.sock'; } >> /etc/my.cnf; \
 	\
 # make sure users dumping files in "/etc/mysql/conf.d" still works
 	! grep -F '!includedir' /etc/my.cnf; \

--- a/template/Dockerfile.oracle
+++ b/template/Dockerfile.oracle
@@ -77,6 +77,7 @@ RUN set -eux; \
 	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
 	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
 	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	{ echo '[client]'; echo 'socket=/var/run/mysqld/mysqld.sock'; } >> /etc/my.cnf; \
 	\
 # make sure users dumping files in "/etc/mysql/conf.d" still works
 	! grep -F '!includedir' /etc/my.cnf; \


### PR DESCRIPTION
The updated `my.cnf` is enough for `mysql` but `mysqlsh --mysql` still uses the compiled in value, so we need the symlink in the data directory. `mysqlsh [user]@localhost` works since it uses the mysqlx port of `33060` by default.

Fixes #829 