### PR TITLE
Update "oracle" variants to be the default variants

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -8,8 +8,8 @@ declare -A aliases=(
 
 defaultDefaultVariant='oracle'
 declare -A defaultVariants=(
-	[5.7]='debian'
-	[8.0]='debian'
+	#[5.7]='debian'
+	#[8.0]='debian'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
The Oracle Linux-based images:

- are smaller (by a pretty non-trivial amount - nearly 100MiB)
- support more architectures (arm64!)
- are more supported/recommended by MySQL upstream

I do not believe it is common for users to install additional packages in images that are `FROM mysql`, but if it is, the Debian-based images are not going away with this change (those users will just have to adapt - either by switching their package installations to Oracle-based packages or by using the Debian-based variants explicitly).