### PR TITLE
Add /etc/mysql/mysql.conf.d in 5.7 Oracle-based images

### DIFF
--- a/5.7/Dockerfile.oracle
+++ b/5.7/Dockerfile.oracle
@@ -89,6 +89,9 @@ RUN set -eux; \
 	! grep -F '!includedir' /etc/my.cnf; \
 	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
 	mkdir -p /etc/mysql/conf.d; \
+# 5.7 Debian-based images also included "/etc/mysql/mysql.conf.d" so let's include it too
+	{ echo '!includedir /etc/mysql/mysql.conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/mysql.conf.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/template/Dockerfile.oracle
+++ b/template/Dockerfile.oracle
@@ -104,6 +104,11 @@ RUN set -eux; \
 	! grep -F '!includedir' /etc/my.cnf; \
 	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
 	mkdir -p /etc/mysql/conf.d; \
+{{ if env.version == "5.7" then ( -}}
+# 5.7 Debian-based images also included "/etc/mysql/mysql.conf.d" so let's include it too
+	{ echo '!includedir /etc/mysql/mysql.conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/mysql.conf.d; \
+{{ ) else "" end -}}
 	\
 	mysqld --version; \
 	mysql --version


### PR DESCRIPTION
This brings them back to parity with Debian (although noting that the Debian-based 8.0 images have never included this, so I'm not adding it there).

Refs #876