### PR TITLE
Fix arbitrary user support on oracle-linux based images

### DIFF
--- a/5.7/Dockerfile.oracle
+++ b/5.7/Dockerfile.oracle
@@ -8,14 +8,7 @@ FROM oraclelinux:7-slim
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
-	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
-	\
-	mkdir /var/lib/mysql /var/run/mysqld; \
-	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
-# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	chmod 1777 /var/lib/mysql /var/run/mysqld; \
-	\
-	mkdir /docker-entrypoint-initdb.d
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
@@ -92,6 +85,20 @@ RUN set -eux; \
 # 5.7 Debian-based images also included "/etc/mysql/mysql.conf.d" so let's include it too
 	{ echo '!includedir /etc/mysql/mysql.conf.d/'; } >> /etc/my.cnf; \
 	mkdir -p /etc/mysql/mysql.conf.d; \
+	\
+# comment out a few problematic configuration values
+	find /etc/my.cnf /etc/mysql/ -name '*.cnf' -print0 \
+		| xargs -0 grep -lZE '^(bind-address|log)' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
+	\
+# ensure these directories exist and have useful permissions
+# the rpm package has different opinions on the mode of `/var/run/mysqld`, so this needs to be after install
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/8.0/Dockerfile.oracle
+++ b/8.0/Dockerfile.oracle
@@ -8,14 +8,7 @@ FROM oraclelinux:8-slim
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
-	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
-	\
-	mkdir /var/lib/mysql /var/run/mysqld; \
-	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
-# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	chmod 1777 /var/lib/mysql /var/run/mysqld; \
-	\
-	mkdir /docker-entrypoint-initdb.d
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
@@ -89,6 +82,14 @@ RUN set -eux; \
 	! grep -F '!includedir' /etc/my.cnf; \
 	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
 	mkdir -p /etc/mysql/conf.d; \
+# ensure these directories exist and have useful permissions
+# the rpm package has different opinions on the mode of `/var/run/mysqld`, so this needs to be after install
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/template/Dockerfile.oracle
+++ b/template/Dockerfile.oracle
@@ -17,14 +17,7 @@ FROM oraclelinux:{{ .oracle.variant }}
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
-	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql; \
-	\
-	mkdir /var/lib/mysql /var/run/mysqld; \
-	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
-# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	chmod 1777 /var/lib/mysql /var/run/mysqld; \
-	\
-	mkdir /docker-entrypoint-initdb.d
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql
 
 # add gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
@@ -108,7 +101,21 @@ RUN set -eux; \
 # 5.7 Debian-based images also included "/etc/mysql/mysql.conf.d" so let's include it too
 	{ echo '!includedir /etc/mysql/mysql.conf.d/'; } >> /etc/my.cnf; \
 	mkdir -p /etc/mysql/mysql.conf.d; \
+	\
+# comment out a few problematic configuration values
+	find /etc/my.cnf /etc/mysql/ -name '*.cnf' -print0 \
+		| xargs -0 grep -lZE '^(bind-address|log)' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
+	\
 {{ ) else "" end -}}
+# ensure these directories exist and have useful permissions
+# the rpm package has different opinions on the mode of `/var/run/mysqld`, so this needs to be after install
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d; \
 	\
 	mysqld --version; \
 	mysql --version


### PR DESCRIPTION
The rpm package has different opinions on the mode of `/var/run/mysqld`, so we have to adjust permissions after install.

When testing running as an arbitrary user, I also found that the `my.cnf` in 5.7 has a `log-error=/var/log/mysqld.log` line which causes startup to break; so this should hopefully fix the missing log level in #880 since they have likely been going to a file :disappointed: :see_no_evil: 

Fixes https://github.com/docker-library/mysql/issues/887 resolves https://github.com/docker-library/mysql/issues/880
