### PR TITLE
Allow for MySQL user w/ empty password

### DIFF
--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -179,7 +179,7 @@ docker_verify_minimum_env() {
 	fi
 
 	# warn when missing one of MYSQL_USER or MYSQL_PASSWORD
-	if [ -n "$MYSQL_USER" ] && [ -z "$MYSQL_PASSWORD" ]; then
+	if [ -n "$MYSQL_USER" ] && [ -z "$MYSQL_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
 		mysql_warn 'MYSQL_USER specified, but missing MYSQL_PASSWORD; MYSQL_USER will not be created'
 	elif [ -z "$MYSQL_USER" ] && [ -n "$MYSQL_PASSWORD" ]; then
 		mysql_warn 'MYSQL_PASSWORD specified, but missing MYSQL_USER; MYSQL_PASSWORD will be ignored'


### PR DESCRIPTION
The value of `MYSQL_ALLOW_EMPTY_PASSWORD` currently only affects the root user. This flag should also determine if the `MYSQL_USER` can be created with an empty password.