### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/8.0/Dockerfile.debian
+++ b/8.0/Dockerfile.debian
@@ -76,7 +76,7 @@ RUN { \
 		echo mysql-community-server mysql-community-server/remove-test-db select false; \
 	} | debconf-set-selections \
 	&& apt-get update \
-	&& apt-get install -y \
+	&& apt-get install -y --no-install-recommends \
 		mysql-community-client="${MYSQL_VERSION}" \
 		mysql-community-server-core="${MYSQL_VERSION}" \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.