### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/template/Dockerfile.debian
+++ b/template/Dockerfile.debian
@@ -70,7 +70,7 @@ RUN { \
 		echo mysql-community-server mysql-community-server/remove-test-db select false; \
 	} | debconf-set-selections \
 	&& apt-get update \
-	&& apt-get install -y \
+	&& apt-get install -y --no-install-recommends \
 {{ if env.version == "5.7" then ( -}}
 		mysql-server="${MYSQL_VERSION}" \
 # comment out a few problematic configuration values


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.
