### PR TITLE
Added some required mysql packages to install list

### DIFF
--- a/template/Dockerfile.debian
+++ b/template/Dockerfile.debian
@@ -80,6 +80,9 @@ RUN { \
 # don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf \
 {{ ) else ( -}}
+        mysql-common="${MYSQL_VERSION}" \
+        mysql-community-client-plugins="${MYSQL_VERSION}" \
+        mysql-community-client-core="${MYSQL_VERSION}" \
 		mysql-community-client="${MYSQL_VERSION}" \
 		mysql-community-server-core="${MYSQL_VERSION}" \
 {{ ) end -}}


### PR DESCRIPTION
Added **some required mysql packages** to install list which are **not installing automatically** of unidentified reason. Without these dependencies the build process fails with "unmet dependencies" error:

The following packages have unmet dependencies:
  mysql-community-client
  Depends: mysql-common (>= 8.0.33-1debian11)
  Depends: mysql-community-client-core (= 8.0.33-1debian11) but it is not installable

**After that need to regenerate the Dockerfile (for Debian)**