### PR TITLE
Add 8.4 (LTS) variant

### DIFF
--- a/8.4/Dockerfile.oracle
+++ b/8.4/Dockerfile.oracle
@@ -1,0 +1,123 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM oraclelinux:8-slim
+
+RUN set -eux; \
+	groupadd --system --gid 999 mysql; \
+	useradd --system --uid 999 --gid 999 --home-dir /var/lib/mysql --no-create-home mysql
+
+# add gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+# TODO find a better userspace architecture detection method than querying the kernel
+	arch="$(uname -m)"; \
+	case "$arch" in \
+		aarch64) gosuArch='arm64' ;; \
+		x86_64) gosuArch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac; \
+	curl -fL -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch.asc"; \
+	curl -fL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$gosuArch"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN set -eux; \
+	microdnf install -y \
+		bzip2 \
+		gzip \
+		openssl \
+		xz \
+		zstd \
+# Oracle Linux 8+ is very slim :)
+		findutils \
+	; \
+	microdnf clean all
+
+RUN set -eux; \
+# https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+# pub   rsa4096 2023-10-23 [SC] [expires: 2025-10-22]
+#       BCA4 3417 C3B4 85DD 128E  C6D4 B7B3 B788 A8D3 785C
+# uid           [ unknown] MySQL Release Engineering <mysql-build@oss.oracle.com>
+# sub   rsa4096 2023-10-23 [E] [expires: 2025-10-22]
+	key='BCA4 3417 C3B4 85DD 128E C6D4 B7B3 B788 A8D3 785C'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	gpg --batch --export --armor "$key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql; \
+	rm -rf "$GNUPGHOME"
+
+ENV MYSQL_MAJOR 8.4
+ENV MYSQL_VERSION 8.4.0-1.el8
+
+RUN set -eu; \
+	{ \
+		echo '[mysql8.4-server-minimal]'; \
+		echo 'name=MySQL 8.4 Server Minimal'; \
+		echo 'enabled=1'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8/$basearch/'; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-minimal.repo
+
+RUN set -eux; \
+	microdnf install -y "mysql-community-server-minimal-$MYSQL_VERSION"; \
+	microdnf clean all; \
+# the "socket" value in the Oracle packages is set to "/var/lib/mysql" which isn't a great place for the socket (we want it in "/var/run/mysqld" instead)
+# https://github.com/docker-library/mysql/pull/680#issuecomment-636121520
+	grep -F 'socket=/var/lib/mysql/mysql.sock' /etc/my.cnf; \
+	sed -i 's!^socket=.*!socket=/var/run/mysqld/mysqld.sock!' /etc/my.cnf; \
+	grep -F 'socket=/var/run/mysqld/mysqld.sock' /etc/my.cnf; \
+	{ echo '[client]'; echo 'socket=/var/run/mysqld/mysqld.sock'; } >> /etc/my.cnf; \
+	\
+# make sure users dumping files in "/etc/mysql/conf.d" still works
+	! grep -F '!includedir' /etc/my.cnf; \
+	{ echo; echo '!includedir /etc/mysql/conf.d/'; } >> /etc/my.cnf; \
+	mkdir -p /etc/mysql/conf.d; \
+# ensure these directories exist and have useful permissions
+# the rpm package has different opinions on the mode of `/var/run/mysqld`, so this needs to be after install
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown mysql:mysql /var/lib/mysql /var/run/mysqld; \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	chmod 1777 /var/lib/mysql /var/run/mysqld; \
+	\
+	mkdir /docker-entrypoint-initdb.d; \
+	\
+	mysqld --version; \
+	mysql --version
+
+RUN set -eu; \
+	{ \
+		echo '[mysql-tools-community]'; \
+		echo 'name=MySQL Tools Community'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8/$basearch/'; \
+		echo 'enabled=1'; \
+		echo 'gpgcheck=1'; \
+		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
+# https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
+		echo 'module_hotfixes=true'; \
+	} | tee /etc/yum.repos.d/mysql-community-tools.repo
+ENV MYSQL_SHELL_VERSION 8.4.0-1.el8
+RUN set -eux; \
+	microdnf install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
+	microdnf clean all; \
+	\
+	mysqlsh --version
+
+VOLUME /var/lib/mysql
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3306 33060
+CMD ["mysqld"]

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -1,0 +1,416 @@
+#!/bin/bash
+set -eo pipefail
+shopt -s nullglob
+
+# logging functions
+mysql_log() {
+	local type="$1"; shift
+	# accept argument string or stdin
+	local text="$*"; if [ "$#" -eq 0 ]; then text="$(cat)"; fi
+	local dt; dt="$(date --rfc-3339=seconds)"
+	printf '%s [%s] [Entrypoint]: %s\n' "$dt" "$type" "$text"
+}
+mysql_note() {
+	mysql_log Note "$@"
+}
+mysql_warn() {
+	mysql_log Warn "$@" >&2
+}
+mysql_error() {
+	mysql_log ERROR "$@" >&2
+	exit 1
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
+
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions
+docker_process_init_files() {
+	# mysql here for backwards compatibility "${mysql[@]}"
+	mysql=( docker_process_sql )
+
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					mysql_note "$0: running $f"
+					"$f"
+				else
+					mysql_note "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+}
+
+# arguments necessary to run "mysqld --verbose --help" successfully (used for testing configuration validity and for extracting default/configured values)
+_verboseHelpArgs=(
+	--verbose --help
+	--log-bin-index="$(mktemp -u)" # https://github.com/docker-library/mysql/issues/136
+)
+
+mysql_check_config() {
+	local toRun=( "$@" "${_verboseHelpArgs[@]}" ) errors
+	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
+		mysql_error $'mysqld failed while attempting to check config\n\tcommand was: '"${toRun[*]}"$'\n\t'"$errors"
+	fi
+}
+
+# Fetch value from server config
+# We use mysqld --verbose --help instead of my_print_defaults because the
+# latter only show values present in config files, and not server defaults
+mysql_get_config() {
+	local conf="$1"; shift
+	"$@" "${_verboseHelpArgs[@]}" 2>/dev/null \
+		| awk -v conf="$conf" '$1 == conf && /^[^ \t]/ { sub(/^[^ \t]+[ \t]+/, ""); print; exit }'
+	# match "datadir      /some/path with/spaces in/it here" but not "--xyz=abc\n     datadir (xyz)"
+}
+
+# Ensure that the package default socket can also be used
+# since rpm packages are compiled with a different socket location
+# and "mysqlsh --mysql" doesn't read the [client] config
+# related to https://github.com/docker-library/mysql/issues/829
+mysql_socket_fix() {
+	local defaultSocket
+	defaultSocket="$(mysql_get_config 'socket' mysqld --no-defaults)"
+	if [ "$defaultSocket" != "$SOCKET" ]; then
+		ln -sfTv "$SOCKET" "$defaultSocket" || :
+	fi
+}
+
+# Do a temporary startup of the MySQL server, for init purposes
+docker_temp_server_start() {
+	# For 5.7+ the server is ready for use as soon as startup command unblocks
+	if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
+		mysql_error "Unable to start server."
+	fi
+}
+
+# Stop the server. When using a local socket file mysqladmin will block until
+# the shutdown is complete.
+docker_temp_server_stop() {
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
+		mysql_error "Unable to shut down server."
+	fi
+}
+
+# Verify that the minimally required password settings are set for new databases.
+docker_verify_minimum_env() {
+	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		mysql_error <<-'EOF'
+			Database is uninitialized and password option is not specified
+			    You need to specify one of the following as an environment variable:
+			    - MYSQL_ROOT_PASSWORD
+			    - MYSQL_ALLOW_EMPTY_PASSWORD
+			    - MYSQL_RANDOM_ROOT_PASSWORD
+		EOF
+	fi
+
+	# This will prevent the CREATE USER from failing (and thus exiting with a half-initialized database)
+	if [ "$MYSQL_USER" = 'root' ]; then
+		mysql_error <<-'EOF'
+			MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
+			    Remove MYSQL_USER="root" and use one of the following to control the root user password:
+			    - MYSQL_ROOT_PASSWORD
+			    - MYSQL_ALLOW_EMPTY_PASSWORD
+			    - MYSQL_RANDOM_ROOT_PASSWORD
+		EOF
+	fi
+
+	# warn when missing one of MYSQL_USER or MYSQL_PASSWORD
+	if [ -n "$MYSQL_USER" ] && [ -z "$MYSQL_PASSWORD" ]; then
+		mysql_warn 'MYSQL_USER specified, but missing MYSQL_PASSWORD; MYSQL_USER will not be created'
+	elif [ -z "$MYSQL_USER" ] && [ -n "$MYSQL_PASSWORD" ]; then
+		mysql_warn 'MYSQL_PASSWORD specified, but missing MYSQL_USER; MYSQL_PASSWORD will be ignored'
+	fi
+}
+
+# creates folders for the database
+# also ensures permission for user mysql of run as root
+docker_create_db_directories() {
+	local user; user="$(id -u)"
+
+	local -A dirs=( ["$DATADIR"]=1 )
+	local dir
+	dir="$(dirname "$SOCKET")"
+	dirs["$dir"]=1
+
+	# "datadir" and "socket" are already handled above (since they were already queried previously)
+	local conf
+	for conf in \
+		general-log-file \
+		keyring_file_data \
+		pid-file \
+		secure-file-priv \
+		slow-query-log-file \
+	; do
+		dir="$(mysql_get_config "$conf" "$@")"
+
+		# skip empty values
+		if [ -z "$dir" ] || [ "$dir" = 'NULL' ]; then
+			continue
+		fi
+		case "$conf" in
+			secure-file-priv)
+				# already points at a directory
+				;;
+			*)
+				# other config options point at a file, but we need the directory
+				dir="$(dirname "$dir")"
+				;;
+		esac
+
+		dirs["$dir"]=1
+	done
+
+	mkdir -p "${!dirs[@]}"
+
+	if [ "$user" = "0" ]; then
+		# this will cause less disk access than `chown -R`
+		find "${!dirs[@]}" \! -user mysql -exec chown --no-dereference mysql '{}' +
+	fi
+}
+
+# initializes the database directory
+docker_init_database_dir() {
+	mysql_note "Initializing database files"
+	"$@" --initialize-insecure --default-time-zone=SYSTEM
+	mysql_note "Database files initialized"
+}
+
+# Loads various settings that are used elsewhere in the script
+# This should be called after mysql_check_config, but before any other functions
+docker_setup_env() {
+	# Get config
+	declare -g DATADIR SOCKET
+	DATADIR="$(mysql_get_config 'datadir' "$@")"
+	SOCKET="$(mysql_get_config 'socket' "$@")"
+
+	# Initialize values that might be stored in a file
+	file_env 'MYSQL_ROOT_HOST' '%'
+	file_env 'MYSQL_DATABASE'
+	file_env 'MYSQL_USER'
+	file_env 'MYSQL_PASSWORD'
+	file_env 'MYSQL_ROOT_PASSWORD'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	if [ -d "$DATADIR/mysql" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# Execute sql script, passed via stdin
+# usage: docker_process_sql [--dont-use-mysql-root-password] [mysql-cli-args]
+#    ie: docker_process_sql --database=mydb <<<'INSERT ...'
+#    ie: docker_process_sql --dont-use-mysql-root-password --database=mydb <my-file.sql
+docker_process_sql() {
+	passfileArgs=()
+	if [ '--dont-use-mysql-root-password' = "$1" ]; then
+		passfileArgs+=( "$1" )
+		shift
+	fi
+	# args sent in can override this db, since they will be later in the command
+	if [ -n "$MYSQL_DATABASE" ]; then
+		set -- --database="$MYSQL_DATABASE" "$@"
+	fi
+
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
+}
+
+# Initializes database with timezone info and root password, plus optional extra db/user
+docker_setup_db() {
+	# Load timezone info into database
+	if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+		# sed is for https://bugs.mysql.com/bug.php?id=20545
+		mysql_tzinfo_to_sql /usr/share/zoneinfo \
+			| sed 's/Local time zone must be set--see zic manual page/FCTY/' \
+			| docker_process_sql --dont-use-mysql-root-password --database=mysql
+			# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
+	fi
+	# Generate random root password
+	if [ -n "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		MYSQL_ROOT_PASSWORD="$(openssl rand -base64 24)"; export MYSQL_ROOT_PASSWORD
+		mysql_note "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
+	fi
+	# Sets root password and creates root users for non-localhost hosts
+	local rootCreate=
+	# default root to listen for connections from anywhere
+	if [ -n "$MYSQL_ROOT_HOST" ] && [ "$MYSQL_ROOT_HOST" != 'localhost' ]; then
+		# no, we don't care if read finds a terminating character in this heredoc
+		# https://unix.stackexchange.com/questions/265149/why-is-set-o-errexit-breaking-this-read-heredoc-expression/265151#265151
+		read -r -d '' rootCreate <<-EOSQL || true
+			CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
+		EOSQL
+	fi
+
+	local passwordSet=
+	# no, we don't care if read finds a terminating character in this heredoc (see above)
+	read -r -d '' passwordSet <<-EOSQL || true
+		ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+	EOSQL
+
+	# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is just now being set
+	docker_process_sql --dont-use-mysql-root-password --database=mysql <<-EOSQL
+		-- What's done in this file shouldn't be replicated
+		--  or products like mysql-fabric won't work
+		SET @@SESSION.SQL_LOG_BIN=0;
+
+		${passwordSet}
+		GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
+		FLUSH PRIVILEGES ;
+		${rootCreate}
+		DROP DATABASE IF EXISTS test ;
+	EOSQL
+
+	# Creates a custom database and user if specified
+	if [ -n "$MYSQL_DATABASE" ]; then
+		mysql_note "Creating database ${MYSQL_DATABASE}"
+		docker_process_sql --database=mysql <<<"CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;"
+	fi
+
+	if [ -n "$MYSQL_USER" ] && [ -n "$MYSQL_PASSWORD" ]; then
+		mysql_note "Creating user ${MYSQL_USER}"
+		docker_process_sql --database=mysql <<<"CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
+
+		if [ -n "$MYSQL_DATABASE" ]; then
+			mysql_note "Giving user ${MYSQL_USER} access to schema ${MYSQL_DATABASE}"
+			docker_process_sql --database=mysql <<<"GRANT ALL ON \`${MYSQL_DATABASE//_/\\_}\`.* TO '$MYSQL_USER'@'%' ;"
+		fi
+	fi
+}
+
+_mysql_passfile() {
+	# echo the password to the "file" the client uses
+	# the client command will use process substitution to create a file on the fly
+	# ie: --defaults-extra-file=<( _mysql_passfile )
+	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+		cat <<-EOF
+			[client]
+			password="${MYSQL_ROOT_PASSWORD}"
+		EOF
+	fi
+}
+
+# Mark root user as expired so the password must be changed before anything
+# else can be done (only supported for 5.6+)
+mysql_expire_root_user() {
+	if [ -n "$MYSQL_ONETIME_PASSWORD" ]; then
+		docker_process_sql --database=mysql <<-EOSQL
+			ALTER USER 'root'@'%' PASSWORD EXPIRE;
+		EOSQL
+	fi
+}
+
+# check arguments for an option that would cause mysqld to stop
+# return true if there is one
+_mysql_want_help() {
+	local arg
+	for arg; do
+		case "$arg" in
+			-'?'|--help|--print-defaults|-V|--version)
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+
+_main() {
+	# if command starts with an option, prepend mysqld
+	if [ "${1:0:1}" = '-' ]; then
+		set -- mysqld "$@"
+	fi
+
+	# skip setup if they aren't running mysqld or want an option that stops mysqld
+	if [ "$1" = 'mysqld' ] && ! _mysql_want_help "$@"; then
+		mysql_note "Entrypoint script for MySQL Server ${MYSQL_VERSION} started."
+
+		mysql_check_config "$@"
+		# Load various environment variables
+		docker_setup_env "$@"
+		docker_create_db_directories "$@"
+
+		# If container is started as root user, restart as dedicated mysql user
+		if [ "$(id -u)" = "0" ]; then
+			mysql_note "Switching to dedicated user 'mysql'"
+			exec gosu mysql "$BASH_SOURCE" "$@"
+		fi
+
+		# there's no database, so it needs to be initialized
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+
+			# check dir permissions to reduce likelihood of half-initialized database
+			ls /docker-entrypoint-initdb.d/ > /dev/null
+
+			docker_init_database_dir "$@"
+
+			mysql_note "Starting temporary server"
+			docker_temp_server_start "$@"
+			mysql_note "Temporary server started."
+
+			mysql_socket_fix
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			mysql_expire_root_user
+
+			mysql_note "Stopping temporary server"
+			docker_temp_server_stop
+			mysql_note "Temporary server stopped"
+
+			echo
+			mysql_note "MySQL init process done. Ready for start up."
+			echo
+		else
+			mysql_socket_fix
+		fi
+	fi
+	exec "$@"
+}
+
+# If we are sourced from elsewhere, don't perform any further actions
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
+	[8.4]='lts'
 	[innovation]='latest'
 )
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,6 @@ set -Eeuo pipefail
 
 declare -A aliases=(
 	[8.4]='lts'
-	[innovation]='latest'
 )
 
 defaultDefaultVariant='oracle'
@@ -13,6 +12,10 @@ declare -A defaultVariants=(
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# add the "latest" alias to the "newest" version (LTS vs innovation; see sorting in "versions.sh")
+latest="$(jq -r 'keys_unsorted[0]' versions.json)"
+aliases["$latest"]+=' latest'
 
 if [ "$#" -eq 0 ]; then
 	versions="$(jq -r 'keys | map(@sh) | join(" ")' versions.json)"
@@ -64,8 +67,18 @@ join() {
 for version; do
 	export version
 
-	defaultVariant="${defaultVariants[$version]:-$defaultDefaultVariant}"
-	fullVersion="$(jq -r '.[env.version].version' versions.json)"
+	if ! fullVersion="$(jq -re '
+		if env.version == "innovation" and keys_unsorted[0] != env.version then
+			# https://github.com/docker-library/mysql/pull/1046#issuecomment-2087323746
+			# if any explicit/LTS release is *newer* than the current innovation release, we should skip innovation
+			# (because we pre-sorted the full list in "versions.sh", we just need to check whether "innovation" is first 🚀)
+			false
+		else
+			.[env.version].version
+		end
+	' versions.json)"; then
+		continue
+	fi
 
 	versionAliases=()
 	while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
@@ -78,6 +91,7 @@ for version; do
 	fi
 	versionAliases+=( ${aliases[$version]:-} )
 
+	defaultVariant="${defaultVariants[$version]:-$defaultDefaultVariant}"
 	for variant in oracle debian; do
 		export variant
 

--- a/versions.json
+++ b/versions.json
@@ -22,6 +22,22 @@
     },
     "version": "8.0.37"
   },
+  "8.4": {
+    "mysql-shell": {
+      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8",
+      "version": "8.4.0-1.el8"
+    },
+    "oracle": {
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ],
+      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8",
+      "variant": "8-slim",
+      "version": "8.4.0-1.el8"
+    },
+    "version": "8.4.0"
+  },
   "innovation": {
     "mysql-shell": {
       "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/8",

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,38 @@
 {
+  "8.4": {
+    "oracle": {
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ],
+      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8",
+      "version": "8.4.0-1.el8",
+      "variant": "8-slim"
+    },
+    "mysql-shell": {
+      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8",
+      "version": "8.4.0-1.el8"
+    },
+    "version": "8.4.0"
+  },
+  "innovation": {
+    "oracle": {
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ],
+      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/8",
+      "version": "8.3.0-1.el8",
+      "variant": "8-slim"
+    },
+    "mysql-shell": {
+      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/8",
+      "version": "8.4.0-1.el8"
+    },
+    "version": "8.3.0"
+  },
   "8.0": {
+    "version": "8.0.37",
     "debian": {
       "architectures": [
         "amd64"
@@ -7,51 +40,18 @@
       "suite": "bookworm",
       "version": "8.0.37-1debian12"
     },
-    "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-community/el/8",
-      "version": "8.0.37-1.el8"
-    },
     "oracle": {
       "architectures": [
         "amd64",
         "arm64v8"
       ],
       "repo": "https://repo.mysql.com/yum/mysql-8.0-community/docker/el/8",
-      "variant": "8-slim",
+      "version": "8.0.37-1.el8",
+      "variant": "8-slim"
+    },
+    "mysql-shell": {
+      "repo": "https://repo.mysql.com/yum/mysql-tools-community/el/8",
       "version": "8.0.37-1.el8"
-    },
-    "version": "8.0.37"
-  },
-  "8.4": {
-    "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8",
-      "version": "8.4.0-1.el8"
-    },
-    "oracle": {
-      "architectures": [
-        "amd64",
-        "arm64v8"
-      ],
-      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8",
-      "variant": "8-slim",
-      "version": "8.4.0-1.el8"
-    },
-    "version": "8.4.0"
-  },
-  "innovation": {
-    "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/8",
-      "version": "8.4.0-1.el8"
-    },
-    "oracle": {
-      "architectures": [
-        "amd64",
-        "arm64v8"
-      ],
-      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/8",
-      "variant": "8-slim",
-      "version": "8.3.0-1.el8"
-    },
-    "version": "8.3.0"
+    }
   }
 }

--- a/versions.sh
+++ b/versions.sh
@@ -105,8 +105,8 @@ for version in "${versions[@]}"; do
 
 	rpmRepo="https://repo.mysql.com/yum/mysql-$version-community/docker/el/$oracleVersion"
 	case "$version" in
-		innovation) toolsRepo="https://repo.mysql.com/yum/mysql-tools-innovation-community/el/$oracleVersion" ;;
-		*)          toolsRepo="https://repo.mysql.com/yum/mysql-tools-community/el/$oracleVersion" ;;
+		8.0) toolsRepo="https://repo.mysql.com/yum/mysql-tools-community/el/$oracleVersion" ;;
+		*)   toolsRepo="https://repo.mysql.com/yum/mysql-tools-$version-community/el/$oracleVersion" ;;
 	esac
 	export rpmRepo toolsRepo
 

--- a/versions.sh
+++ b/versions.sh
@@ -172,4 +172,16 @@ for version in "${versions[@]}"; do
 	json="$(jq <<<"$json" -c --argjson doc "$doc" '.[env.version] = $doc')"
 done
 
-jq <<<"$json" -S . > versions.json
+jq <<<"$json" '
+	# sort entries in descending version order so that it is easier to determine later (in "generate-stackbrew-library.sh") if "innovation" should be included or not, and which entry to give the "latest" alias to (the first one!)
+	# https://github.com/docker-library/mysql/pull/1046#issuecomment-2087323746
+	to_entries
+	| sort_by(
+		# very rough "sort by version number"
+		.value.version
+		| split(".")
+		| map(tonumber? // .)
+	)
+	| reverse
+	| from_entries
+' > versions.json


### PR DESCRIPTION
This PR adds 8.4, the new LTS release, as variant. See also https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html.

To do so, the `update.sh` script has been updated to use `"https://repo.mysql.com/yum/mysql-tools-$version-community/el/$oracleVersion"` as new default url for tools, hoping this is the new convention (didn't check for any official statements); see also https://repo.mysql.com/yum/.

No Debian variant was added per https://github.com/docker-library/mysql/pull/867#issuecomment-1171533195.

Moreover, I've taken the liberty to add an `lts` alias, which seems appropriate to me. If not, feel free to (ask me to) remove that.

Finally, when going through the sources I noticed that Oracle Linux 9 has been released a while back. I could not find any support policies regarding OS versions for this image so quickly, but if variants are preferably kept on the same OS for stability, considering to use v9 for this variant is probably appropriate. Otherwise, updating could be left as a separate (unrelated) follow-up PR.