### PR TITLE
Use Oracle Linux 9 as base image

### DIFF
--- a/8.0/Dockerfile.oracle
+++ b/8.0/Dockerfile.oracle
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM oraclelinux:8-slim
+FROM oraclelinux:9-slim
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
@@ -56,14 +56,14 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.37-1.el8
+ENV MYSQL_VERSION 8.0.37-1.el9
 
 RUN set -eu; \
 	{ \
 		echo '[mysql8.0-server-minimal]'; \
 		echo 'name=MySQL 8.0 Server Minimal'; \
 		echo 'enabled=1'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-8.0-community/docker/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-8.0-community/docker/el/9/$basearch/'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
@@ -100,14 +100,14 @@ RUN set -eu; \
 	{ \
 		echo '[mysql-tools-community]'; \
 		echo 'name=MySQL Tools Community'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-community/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-community/el/9/$basearch/'; \
 		echo 'enabled=1'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
 		echo 'module_hotfixes=true'; \
 	} | tee /etc/yum.repos.d/mysql-community-tools.repo
-ENV MYSQL_SHELL_VERSION 8.0.37-1.el8
+ENV MYSQL_SHELL_VERSION 8.0.37-1.el9
 RUN set -eux; \
 	microdnf install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
 	microdnf clean all; \

--- a/8.4/Dockerfile.oracle
+++ b/8.4/Dockerfile.oracle
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM oraclelinux:8-slim
+FROM oraclelinux:9-slim
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
@@ -56,14 +56,14 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 ENV MYSQL_MAJOR 8.4
-ENV MYSQL_VERSION 8.4.0-1.el8
+ENV MYSQL_VERSION 8.4.0-1.el9
 
 RUN set -eu; \
 	{ \
 		echo '[mysql8.4-server-minimal]'; \
 		echo 'name=MySQL 8.4 Server Minimal'; \
 		echo 'enabled=1'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-8.4-community/docker/el/9/$basearch/'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
@@ -100,14 +100,14 @@ RUN set -eu; \
 	{ \
 		echo '[mysql-tools-community]'; \
 		echo 'name=MySQL Tools Community'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-8.4-community/el/9/$basearch/'; \
 		echo 'enabled=1'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
 		echo 'module_hotfixes=true'; \
 	} | tee /etc/yum.repos.d/mysql-community-tools.repo
-ENV MYSQL_SHELL_VERSION 8.4.0-1.el8
+ENV MYSQL_SHELL_VERSION 8.4.0-1.el9
 RUN set -eux; \
 	microdnf install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
 	microdnf clean all; \

--- a/versions.json
+++ b/versions.json
@@ -5,13 +5,13 @@
         "amd64",
         "arm64v8"
       ],
-      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/8",
-      "version": "8.4.0-1.el8",
-      "variant": "8-slim"
+      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/9",
+      "version": "8.4.0-1.el9",
+      "variant": "9-slim"
     },
     "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/8",
-      "version": "8.4.0-1.el8"
+      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/9",
+      "version": "8.4.0-1.el9"
     },
     "version": "8.4.0"
   },
@@ -45,13 +45,13 @@
         "amd64",
         "arm64v8"
       ],
-      "repo": "https://repo.mysql.com/yum/mysql-8.0-community/docker/el/8",
-      "version": "8.0.37-1.el8",
-      "variant": "8-slim"
+      "repo": "https://repo.mysql.com/yum/mysql-8.0-community/docker/el/9",
+      "version": "8.0.37-1.el9",
+      "variant": "9-slim"
     },
     "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-community/el/8",
-      "version": "8.0.37-1.el8"
+      "repo": "https://repo.mysql.com/yum/mysql-tools-community/el/9",
+      "version": "8.0.37-1.el9"
     }
   }
 }

--- a/versions.sh
+++ b/versions.sh
@@ -6,9 +6,9 @@ declare -A debianSuites=(
 	#[5.7]='buster'
 )
 
-defaultOracleVariant='8-slim'
+defaultOracleVariant='9-slim'
 declare -A oracleVariants=(
-	#[5.7]='7-slim'
+	[innovation]='8-slim'
 )
 
 # https://repo.mysql.com/yum/mysql-8.0-community/docker/


### PR DESCRIPTION
This updates the base OS image to Oracle Linux 9, as a follow-up to https://github.com/docker-library/mysql/pull/1046.

However, currently the innovation release only has a Docker-specific package for v8 (see https://repo.mysql.com/yum/mysql-innovation-community/docker/el/), where both 8.0 and 8.4 do have v9 specific releases. Given that the recent 8.0.37 is the only version in the 8.0 series with a v9 package (see https://repo.mysql.com/yum/mysql-8.0-community/docker/el/9/x86_64/), I *suspect* that going forward v9 packages will be released and the next innovation release will also have a v9 variant.

Therefore it's probably wise to:
- Merge this now and make sure to doublecheck this at the next innovation release, to remove the variant override added here;
- Hold off on merging this until the next innovation release (in approx. 3 months) and then update all images at once.