### PR TITLE
Make sure that in the event of a tie between "release pockets", we prefer non-innovation

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -16,6 +16,11 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 # add the "latest" alias to the "newest" version (LTS vs innovation; see sorting in "versions.sh")
 latest="$(jq -r 'keys_unsorted[0]' versions.json)"
 aliases["$latest"]+=' latest'
+# if "innovation" currently is in line with an LTS, add the "innovation" alias to the LTS release
+innovation="$(jq -r 'to_entries | if .[0].value.version == .[1].value.version and .[1].key == "innovation" then .[0].key else "innovation" end' versions.json)"
+if [ "$innovation" != 'innovation' ]; then
+	aliases["$innovation"]+=' innovation'
+fi
 
 if [ "$#" -eq 0 ]; then
 	versions="$(jq -r 'keys | map(@sh) | join(" ")' versions.json)"

--- a/versions.sh
+++ b/versions.sh
@@ -177,10 +177,17 @@ jq <<<"$json" '
 	# https://github.com/docker-library/mysql/pull/1046#issuecomment-2087323746
 	to_entries
 	| sort_by(
-		# very rough "sort by version number"
-		.value.version
-		| split(".")
-		| map(tonumber? // .)
+		[
+			(
+				# very rough "sort by version number"
+				.value.version
+				| split(".")
+				| map(tonumber? // .)
+			),
+			# when two versions are equal (8.4.0 copied to "innovation" *and* in "8.4", for example), prefer the LTS/explicit release over "innovation"
+			.key != "innovation"
+			# (false sorts above true, but then we reverse)
+		]
 	)
 	| reverse
 	| from_entries


### PR DESCRIPTION
Right now, we're in the unique situation of "innovation" containing 8.4.0 just like "8.4" does, but we want to prefer the "lts" branch (and add the "innovation" alias to it 👀).

Follow-up, of sorts, to https://github.com/docker-library/mysql/pull/1046