### PR TITLE
Use Oracle Linux 9 as base image for innovation image

### DIFF
--- a/innovation/Dockerfile.oracle
+++ b/innovation/Dockerfile.oracle
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM oraclelinux:8-slim
+FROM oraclelinux:9-slim
 
 RUN set -eux; \
 	groupadd --system --gid 999 mysql; \
@@ -56,14 +56,14 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 ENV MYSQL_MAJOR innovation
-ENV MYSQL_VERSION 8.4.0-1.el8
+ENV MYSQL_VERSION 9.0.0-1.el9
 
 RUN set -eu; \
 	{ \
 		echo '[mysqlinnovation-server-minimal]'; \
 		echo 'name=MySQL innovation Server Minimal'; \
 		echo 'enabled=1'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-innovation-community/docker/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-innovation-community/docker/el/9/$basearch/'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
@@ -100,14 +100,14 @@ RUN set -eu; \
 	{ \
 		echo '[mysql-tools-community]'; \
 		echo 'name=MySQL Tools Community'; \
-		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-innovation-community/el/8/$basearch/'; \
+		echo 'baseurl=https://repo.mysql.com/yum/mysql-tools-innovation-community/el/9/$basearch/'; \
 		echo 'enabled=1'; \
 		echo 'gpgcheck=1'; \
 		echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'; \
 # https://github.com/docker-library/mysql/pull/680#issuecomment-825930524
 		echo 'module_hotfixes=true'; \
 	} | tee /etc/yum.repos.d/mysql-community-tools.repo
-ENV MYSQL_SHELL_VERSION 9.0.0-1.el8
+ENV MYSQL_SHELL_VERSION 9.0.0-1.el9
 RUN set -eux; \
 	microdnf install -y "mysql-shell-$MYSQL_SHELL_VERSION"; \
 	microdnf clean all; \

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,20 @@
 {
+  "innovation": {
+    "oracle": {
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ],
+      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/9",
+      "version": "9.0.0-1.el9",
+      "variant": "9-slim"
+    },
+    "mysql-shell": {
+      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/9",
+      "version": "9.0.0-1.el9"
+    },
+    "version": "9.0.0"
+  },
   "8.4": {
     "oracle": {
       "architectures": [
@@ -14,22 +30,6 @@
       "version": "8.4.1-1.el9"
     },
     "version": "8.4.1"
-  },
-  "innovation": {
-    "oracle": {
-      "architectures": [
-        "amd64",
-        "arm64v8"
-      ],
-      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/8",
-      "version": "8.4.0-1.el8",
-      "variant": "8-slim"
-    },
-    "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/8",
-      "version": "9.0.0-1.el8"
-    },
-    "version": "8.4.0"
   },
   "8.0": {
     "version": "8.0.38",

--- a/versions.sh
+++ b/versions.sh
@@ -8,7 +8,7 @@ declare -A debianSuites=(
 
 defaultOracleVariant='9-slim'
 declare -A oracleVariants=(
-	[innovation]='8-slim'
+	#[innovation]='8-slim'
 )
 
 # https://repo.mysql.com/yum/mysql-8.0-community/docker/


### PR DESCRIPTION
Follow-up to #1047, this updates the `innovation` image to use Oracle Linux 9 as base OS image. This also allows it to correctly use the latest MySQL release ([9.0.0](https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html)) to be used.

For some reason, this prompts the update script to interchange "8.4" and "innovation" in `versions.json`, which combined with updating both the OS and the version to the same number (9) results in a somewhat confusing git diff ;)