### PR TITLE
Use jq's `IN()` instead of `index()`

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -87,7 +87,7 @@ VOLUME /var/lib/mysql
 # Config files
 COPY config/ /etc/mysql/
 COPY docker-entrypoint.sh /usr/local/bin/
-{{ if [ "8.0" ] | index(env.version) then ( -}}
+{{ if env.version == "8.0" then ( -}}
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 {{ ) else "" end -}}
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile.oracle
+++ b/Dockerfile.oracle
@@ -132,7 +132,7 @@ RUN set -eux; \
 VOLUME /var/lib/mysql
 
 COPY docker-entrypoint.sh /usr/local/bin/
-{{ if [ "8.0" ] | index(env.version) then ( -}}
+{{ if env.version == "8.0" then ( -}}
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 {{ ) else "" end -}}
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
The end result is the same, but the construction is more ergonomic ( :trollface: ).

See also https://github.com/docker-library/buildpack-deps/pull/165 (and linked)