### PR TITLE
Use Oracle Linux 10 as base image for innovation and 8.4 (lts)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -5,13 +5,13 @@
         "amd64",
         "arm64v8"
       ],
-      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/9",
-      "version": "9.4.0-1.el9",
+      "repo": "https://repo.mysql.com/yum/mysql-innovation-community/docker/el/10",
+      "version": "9.4.0-1.el10",
       "variant": "9-slim"
     },
     "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/9",
-      "version": "9.4.0-1.el9"
+      "repo": "https://repo.mysql.com/yum/mysql-tools-innovation-community/el/10",
+      "version": "9.4.0-1.el10"
     },
     "version": "9.4.0"
   },
@@ -21,13 +21,13 @@
         "amd64",
         "arm64v8"
       ],
-      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/9",
-      "version": "8.4.6-1.el9",
+      "repo": "https://repo.mysql.com/yum/mysql-8.4-community/docker/el/10",
+      "version": "8.4.6-1.el10",
       "variant": "9-slim"
     },
     "mysql-shell": {
-      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/9",
-      "version": "8.4.6-1.el9"
+      "repo": "https://repo.mysql.com/yum/mysql-tools-8.4-community/el/10",
+      "version": "8.4.6-1.el10"
     },
     "version": "8.4.6"
   },

--- a/versions.sh
+++ b/versions.sh
@@ -6,9 +6,9 @@ declare -A debianSuites=(
 	#[5.7]='buster'
 )
 
-defaultOracleVariant='9-slim'
+defaultOracleVariant='10-slim'
 declare -A oracleVariants=(
-	#[innovation]='8-slim'
+	[8.0]='9-slim'
 )
 
 # https://repo.mysql.com/yum/mysql-8.0-community/docker/


### PR DESCRIPTION
Modeled after #1076, this PR updates the base Oracle Linux version to 10 (see also https://blogs.oracle.com/linux/post/oracle-linux-10-now-generally-available and https://github.com/docker-library/official-images/pull/19442).

Note that this is still incomplete, given that while tooling seems available for v10 (see e.g. https://repo.mysql.com/yum/mysql-tools-innovation-community/el/10), the Docker specific builds are not available just yet (see e.g. https://repo.mysql.com/yum/mysql-innovation-community/docker/el/).

Finally there seem to be no v10 builds for 8.0, which makes sense given its expected EOL in April 2026, so this PR for now assumes this will keep v9 as base version.