### PR TITLE
Log which init file failed in docker_process_init_files (fixes #1026)

### DIFF
--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -66,17 +66,17 @@ docker_process_init_files() {
 				# https://github.com/docker-library/postgres/pull/452
 				if [ -x "$f" ]; then
 					mysql_note "$0: running $f"
-					"$f"
+					"$f" || mysql_error "$0: failed while running $f"
 				else
 					mysql_note "$0: sourcing $f"
-					. "$f"
+					. "$f" || mysql_error "$0: failed while sourcing $f"
 				fi
 				;;
-			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql; echo ;;
-			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f" || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -66,17 +66,17 @@ docker_process_init_files() {
 				# https://github.com/docker-library/postgres/pull/452
 				if [ -x "$f" ]; then
 					mysql_note "$0: running $f"
-					"$f"
+					"$f" || mysql_error "$0: failed while running $f"
 				else
 					mysql_note "$0: sourcing $f"
-					. "$f"
+					. "$f" || mysql_error "$0: failed while sourcing $f"
 				fi
 				;;
-			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql; echo ;;
-			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f" || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -66,17 +66,17 @@ docker_process_init_files() {
 				# https://github.com/docker-library/postgres/pull/452
 				if [ -x "$f" ]; then
 					mysql_note "$0: running $f"
-					"$f"
+					"$f" || mysql_error "$0: failed while running $f"
 				else
 					mysql_note "$0: sourcing $f"
-					. "$f"
+					. "$f" || mysql_error "$0: failed while sourcing $f"
 				fi
 				;;
-			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql; echo ;;
-			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql < "$f" || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql || mysql_error "$0: failed while running $f"; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo


### PR DESCRIPTION
When a script or SQL file in /docker-entrypoint-initdb.d/ fails during container initialization, the container exits but gives no indication of which file caused the error. This makes debugging difficult, especially when many init files are present.

Add `|| mysql_error` to every execution path in docker_process_init_files so that on failure the log clearly names the file that failed:

  [ERROR] [Entrypoint]: entrypoint.sh: failed while running /docker-entrypoint-initdb.d/02_seed.sql

Applies to: executable .sh, sourced .sh, .sql, .sql.gz, .sql.bz2,
            .sql.xz, and .sql.zst file types.