### PR TITLE
Adding support for database startup scripts

### DIFF
--- a/8.4/Dockerfile.oracle
+++ b/8.4/Dockerfile.oracle
@@ -92,6 +92,7 @@ RUN set -eux; \
 	chmod 1777 /var/lib/mysql /var/run/mysqld; \
 	\
 	mkdir /docker-entrypoint-initdb.d; \
+	mkdir /docker-entrypoint-startdb.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	
+
 	echo
 	local f
 	for f; do
@@ -286,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -359,16 +359,12 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-		return
+	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+		cat <<-EOF
+			[client]
+			password="${MYSQL_ROOT_PASSWORD}"
+		EOF
 	fi
-
-
-	cat <<-EOF
-		[client]
-		user=root
-		password="${MYSQL_ROOT_PASSWORD}"
-	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -56,7 +56,6 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	echo executing scripts in $1
 	echo
 	local f
 	for f; do
@@ -77,6 +76,38 @@ docker_process_init_files() {
 			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
 			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+}
+
+# usage: docker_process_start_files [file [file [...]]]
+#    ie: docker_process_start_files /always-initdb.d/*
+# process startup files, based on file extensions
+docker_process_start_files() {
+	# mysql here for backwards compatibility "${mysql[@]}"
+	mysql=( docker_process_sql )
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					mysql_note "$0: running $f"
+					"$f"
+				else
+					mysql_note "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql --database=$MYSQL_DATABASE < "$f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
@@ -406,13 +437,13 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif [ -n "$MYSQL_DATABASE" ] && find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."
 
 			mysql_socket_fix
-			docker_process_init_files /docker-entrypoint-startdb.d/*
+			docker_process_start_files /docker-entrypoint-startdb.d/*
 
 			mysql_note "Stopping temporary server"
 			docker_temp_server_stop

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -56,6 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
+	
 	echo
 	local f
 	for f; do
@@ -160,7 +161,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -406,11 +406,24 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
+		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+			mysql_note "Starting temporary server"
+			docker_temp_server_start "$@"
+			mysql_note "Temporary server started."
+
+			mysql_socket_fix
+			docker_process_init_files /docker-entrypoint-startdb.d/*
+
+			mysql_note "Stopping temporary server"
+			docker_temp_server_stop
+			mysql_note "Temporary server stopped"
+
+			echo
+			mysql_note "MySQL pre-start process done. Ready for start up."
+			echo
 		else
 			mysql_socket_fix
 		fi
-		
-		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -409,6 +409,8 @@ _main() {
 		else
 			mysql_socket_fix
 		fi
+		
+		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-
+	echo executing scripts in $1
 	echo
 	local f
 	for f; do

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -406,7 +406,7 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -362,10 +362,10 @@ _mysql_passfile() {
 		return
 	fi
 
-	local user="${MYSQL_ROOT_USER:-root}"
+
 	cat <<-EOF
 		[client]
-		user="${user}"
+		user=root
 		password="${MYSQL_ROOT_PASSWORD}"
 	EOF
 }

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -160,7 +160,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +285,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -358,12 +358,16 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
-		cat <<-EOF
-			[client]
-			password="${MYSQL_ROOT_PASSWORD}"
-		EOF
+	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+		return
 	fi
+
+	local user="${MYSQL_ROOT_USER:-root}"
+	cat <<-EOF
+		[client]
+		user="${user}"
+		password="${MYSQL_ROOT_PASSWORD}"
+	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/9.7/Dockerfile.oracle
+++ b/9.7/Dockerfile.oracle
@@ -92,6 +92,7 @@ RUN set -eux; \
 	chmod 1777 /var/lib/mysql /var/run/mysqld; \
 	\
 	mkdir /docker-entrypoint-initdb.d; \
+	mkdir /docker-entrypoint-startdb.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -362,11 +362,11 @@ _mysql_passfile() {
 		return
 	fi
 
-	local user="${MYSQL_ROOT_USER:-root}"
+
 	cat <<-EOF
 		[client]
-		user="${user}"
-		password="${MYSQL_ROOT_PASSWORD}"
+		user=root
+		password=${MYSQL_ROOT_PASSWORD}
 	EOF
 }
 

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	
+
 	echo
 	local f
 	for f; do
@@ -286,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -359,16 +359,12 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-		return
+	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+		cat <<-EOF
+			[client]
+			password="${MYSQL_ROOT_PASSWORD}"
+		EOF
 	fi
-
-
-	cat <<-EOF
-		[client]
-		user=root
-		password="${MYSQL_ROOT_PASSWORD}"
-	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -56,7 +56,6 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	echo executing scripts in $1
 	echo
 	local f
 	for f; do
@@ -77,6 +76,38 @@ docker_process_init_files() {
 			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
 			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+}
+
+# usage: docker_process_start_files [file [file [...]]]
+#    ie: docker_process_start_files /always-initdb.d/*
+# process startup files, based on file extensions
+docker_process_start_files() {
+	# mysql here for backwards compatibility "${mysql[@]}"
+	mysql=( docker_process_sql )
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					mysql_note "$0: running $f"
+					"$f"
+				else
+					mysql_note "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql --database=$MYSQL_DATABASE < "$f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
@@ -406,13 +437,13 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif [ -n "$MYSQL_DATABASE" ] && find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."
 
 			mysql_socket_fix
-			docker_process_init_files /docker-entrypoint-startdb.d/*
+			docker_process_start_files /docker-entrypoint-startdb.d/*
 
 			mysql_note "Stopping temporary server"
 			docker_temp_server_stop

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -56,6 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
+	
 	echo
 	local f
 	for f; do
@@ -160,7 +161,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -366,7 +367,7 @@ _mysql_passfile() {
 	cat <<-EOF
 		[client]
 		user=root
-		password=${MYSQL_ROOT_PASSWORD}
+		password="${MYSQL_ROOT_PASSWORD}"
 	EOF
 }
 

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -406,11 +406,24 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
+		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+			mysql_note "Starting temporary server"
+			docker_temp_server_start "$@"
+			mysql_note "Temporary server started."
+
+			mysql_socket_fix
+			docker_process_init_files /docker-entrypoint-startdb.d/*
+
+			mysql_note "Stopping temporary server"
+			docker_temp_server_stop
+			mysql_note "Temporary server stopped"
+
+			echo
+			mysql_note "MySQL pre-start process done. Ready for start up."
+			echo
 		else
 			mysql_socket_fix
 		fi
-		
-		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -409,6 +409,8 @@ _main() {
 		else
 			mysql_socket_fix
 		fi
+		
+		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-
+	echo executing scripts in $1
 	echo
 	local f
 	for f; do

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -406,7 +406,7 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."

--- a/9.7/docker-entrypoint.sh
+++ b/9.7/docker-entrypoint.sh
@@ -160,7 +160,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +285,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -358,12 +358,16 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
-		cat <<-EOF
-			[client]
-			password="${MYSQL_ROOT_PASSWORD}"
-		EOF
+	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+		return
 	fi
+
+	local user="${MYSQL_ROOT_USER:-root}"
+	cat <<-EOF
+		[client]
+		user="${user}"
+		password="${MYSQL_ROOT_PASSWORD}"
+	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/Dockerfile.oracle
+++ b/Dockerfile.oracle
@@ -107,6 +107,7 @@ RUN set -eux; \
 	chmod 1777 /var/lib/mysql /var/run/mysqld; \
 	\
 	mkdir /docker-entrypoint-initdb.d; \
+	mkdir /docker-entrypoint-startdb.d; \
 	\
 	mysqld --version; \
 	mysql --version

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -362,11 +362,11 @@ _mysql_passfile() {
 		return
 	fi
 
-	local user="${MYSQL_ROOT_USER:-root}"
+
 	cat <<-EOF
 		[client]
-		user="${user}"
-		password="${MYSQL_ROOT_PASSWORD}"
+		user=root
+		password=${MYSQL_ROOT_PASSWORD}
 	EOF
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	
+
 	echo
 	local f
 	for f; do
@@ -286,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -359,16 +359,12 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-		return
+	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+		cat <<-EOF
+			[client]
+			password="${MYSQL_ROOT_PASSWORD}"
+		EOF
 	fi
-
-
-	cat <<-EOF
-		[client]
-		user=root
-		password="${MYSQL_ROOT_PASSWORD}"
-	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	echo executing scripts in $1
+	echo executing script $1
 	echo
 	local f
 	for f; do
@@ -406,11 +406,24 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
+		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+			mysql_note "Starting temporary server"
+			docker_temp_server_start "$@"
+			mysql_note "Temporary server started."
+
+			mysql_socket_fix
+			docker_process_init_files /docker-entrypoint-startdb.d/*
+
+			mysql_note "Stopping temporary server"
+			docker_temp_server_stop
+			mysql_note "Temporary server stopped"
+
+			echo
+			mysql_note "MySQL pre-start process done. Ready for start up."
+			echo
 		else
 			mysql_socket_fix
 		fi
-		
-		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,6 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-	echo executing script $1
 	echo
 	local f
 	for f; do
@@ -77,6 +76,38 @@ docker_process_init_files() {
 			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
 			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         mysql_warn "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+}
+
+# usage: docker_process_start_files [file [file [...]]]
+#    ie: docker_process_start_files /always-initdb.d/*
+# process startup files, based on file extensions
+docker_process_start_files() {
+	# mysql here for backwards compatibility "${mysql[@]}"
+	mysql=( docker_process_sql )
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					mysql_note "$0: running $f"
+					"$f"
+				else
+					mysql_note "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)     mysql_note "$0: running $f"; docker_process_sql --database=$MYSQL_DATABASE < "$f"; echo ;;
+			*.sql.bz2) mysql_note "$0: running $f"; bunzip2 -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.gz)  mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.xz)  mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
+			*.sql.zst) mysql_note "$0: running $f"; zstd -dc "$f" | docker_process_sql --database=$MYSQL_DATABASE; echo ;;
 			*)         mysql_warn "$0: ignoring $f" ;;
 		esac
 		echo
@@ -406,13 +437,13 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif [ -n "$MYSQL_DATABASE" ] && find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."
 
 			mysql_socket_fix
-			docker_process_init_files /docker-entrypoint-startdb.d/*
+			docker_process_start_files /docker-entrypoint-startdb.d/*
 
 			mysql_note "Stopping temporary server"
 			docker_temp_server_stop

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-
+	echo execution scripts in $1
 	echo
 	local f
 	for f; do

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,6 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
+	
 	echo
 	local f
 	for f; do
@@ -160,7 +161,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +286,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -366,7 +367,7 @@ _mysql_passfile() {
 	cat <<-EOF
 		[client]
 		user=root
-		password=${MYSQL_ROOT_PASSWORD}
+		password="${MYSQL_ROOT_PASSWORD}"
 	EOF
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -409,6 +409,8 @@ _main() {
 		else
 			mysql_socket_fix
 		fi
+		
+		docker_process_init_files /docker-entrypoint-startdb.d/*
 	fi
 	exec "$@"
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,7 +56,7 @@ _is_sourced() {
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
-
+	echo executing scripts in $1
 	echo
 	local f
 	for f; do

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -406,7 +406,7 @@ _main() {
 			echo
 			mysql_note "MySQL init process done. Ready for start up."
 			echo
-		else if find /docker-entrypoint-startdb.d/ -type f | read -r _; then
+		elif find /docker-entrypoint-startdb.d/ -type f | read -r _; then
 			mysql_note "Starting temporary server"
 			docker_temp_server_start "$@"
 			mysql_note "Temporary server started."

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -160,7 +160,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -285,7 +285,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -358,12 +358,16 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
-		cat <<-EOF
-			[client]
-			password="${MYSQL_ROOT_PASSWORD}"
-		EOF
+	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+		return
 	fi
+
+	local user="${MYSQL_ROOT_USER:-root}"
+	cat <<-EOF
+		[client]
+		user="${user}"
+		password="${MYSQL_ROOT_PASSWORD}"
+	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/innovation/docker-entrypoint.sh
+++ b/innovation/docker-entrypoint.sh
@@ -331,10 +331,10 @@ _mysql_passfile() {
 		return
 	fi
 
-	local user="${MYSQL_ROOT_USER:-root}"
+
 	cat <<-EOF
 		[client]
-		user="${user}"
+		user=root
 		password="${MYSQL_ROOT_PASSWORD}"
 	EOF
 }

--- a/innovation/docker-entrypoint.sh
+++ b/innovation/docker-entrypoint.sh
@@ -129,7 +129,7 @@ docker_temp_server_start() {
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
+	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown --socket="${SOCKET}"; then
 		mysql_error "Unable to shut down server."
 	fi
 }
@@ -254,7 +254,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -327,12 +327,16 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
-		cat <<-EOF
-			[client]
-			password="${MYSQL_ROOT_PASSWORD}"
-		EOF
+	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+		return
 	fi
+
+	local user="${MYSQL_ROOT_USER:-root}"
+	cat <<-EOF
+		[client]
+		user="${user}"
+		password="${MYSQL_ROOT_PASSWORD}"
+	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything

--- a/innovation/docker-entrypoint.sh
+++ b/innovation/docker-entrypoint.sh
@@ -254,7 +254,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user

--- a/innovation/docker-entrypoint.sh
+++ b/innovation/docker-entrypoint.sh
@@ -254,7 +254,7 @@ docker_process_sql() {
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
 
-	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -hlocalhost -uroot --socket="${SOCKET}" --comments "$@"
+	mysql --defaults-extra-file=<( _mysql_passfile "${passfileArgs[@]}") --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --comments "$@"
 }
 
 # Initializes database with timezone info and root password, plus optional extra db/user
@@ -327,16 +327,13 @@ _mysql_passfile() {
 	# echo the password to the "file" the client uses
 	# the client command will use process substitution to create a file on the fly
 	# ie: --defaults-extra-file=<( _mysql_passfile )
-	if [ '--dont-use-mysql-root-password' = "$1" ] || [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-		return
+	if [ '--dont-use-mysql-root-password' != "$1" ] && [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+		cat <<-EOF
+			[client]
+			user=root
+			password="${MYSQL_ROOT_PASSWORD}"
+		EOF
 	fi
-
-
-	cat <<-EOF
-		[client]
-		user=root
-		password="${MYSQL_ROOT_PASSWORD}"
-	EOF
 }
 
 # Mark root user as expired so the password must be changed before anything


### PR DESCRIPTION
There are instances where you want to run scripts when the container starts, and not just when the database is first created.  Here are some examples where this feature would be useful:

- You're starting an e2e (end-to-end) test run and you need to get the database to a "good" state.
- You're using an ORM (object-relational-mapper) library like [entity framework](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#idempotent-sql-scripts) that generates an idempotent that should be run on every startup to ensure the database is in a good state.

This merge request adds this capability by creating a new "/docker-entrypoint-startdb.d/" folder; files placed in this folder will be run on every container startup.

NOTE: The DockerHub image page description will need to be updated, with text that looks similar to this:

```txt
Running scripts on database startup
Each time this container image is started, it will execute files with extensions .sh, .sql, .sql.gz, .sql.bz2, .sql.xz, and .sql.zst that are found in /docker-entrypoint-startdb.d. Files will be executed in alphabetical order. When parsing .sh files without the execute bit set, they are sourced rather than executed.
```